### PR TITLE
Add JDBC URL support for PostgreSQL configuration

### DIFF
--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,18 +1,29 @@
 databases:
+  # SQLite configuration examples
   dev-db:
     type: sqlite
     path: /path/to/dev.db
     password: 
-  
+
+  # PostgreSQL configuration examples
+  # Standard configuration
   test-db:
-    type: sqlite
-    path: /path/to/test.db
+    type: postgres
+    host: postgres.example.com
+    port: 5432
+    dbname: test_db
+    user: test_user
     password: test_pass
 
+  # JDBC URL configuration
+  # Note: When using JDBC URL in code, provide credentials separately:
+  # PostgresConfig.from_jdbc_url(
+  #   "jdbc:postgresql://prod.example.com:5432/prod_db",
+  #   user="prod_user",
+  #   password="your@special#password"
+  # )
   prod-db:
     type: postgres
-    host: prod.example.com
-    port: 5432
-    dbname: prod_db
+    jdbc_url: jdbc:postgresql://postgres.example.com:5432/prod-db
     user: prod_user
     password: prod_pass

--- a/src/mcp_dbutils/postgres/config.py
+++ b/src/mcp_dbutils/postgres/config.py
@@ -1,7 +1,39 @@
 """PostgreSQL configuration module"""
 from dataclasses import dataclass
 from typing import Optional, Dict, Any, Literal
+from urllib.parse import urlparse
 from ..config import DatabaseConfig
+
+def parse_jdbc_url(jdbc_url: str) -> Dict[str, str]:
+    """Parse JDBC URL into connection parameters
+    
+    Args:
+        jdbc_url: JDBC URL (e.g. jdbc:postgresql://host:port/dbname)
+        
+    Returns:
+        Dictionary of connection parameters
+    """
+    if not jdbc_url.startswith('jdbc:postgresql://'):
+        raise ValueError("Invalid PostgreSQL JDBC URL format")
+    
+    # Remove jdbc: prefix and ensure no credentials in URL
+    url = jdbc_url[5:]
+    if '@' in url:
+        raise ValueError("JDBC URL should not contain credentials. Please provide username and password separately.")
+    
+    # Parse URL
+    parsed = urlparse(url)
+    
+    params = {
+        'host': parsed.hostname or 'localhost',
+        'port': str(parsed.port or 5432),
+        'dbname': parsed.path.lstrip('/') if parsed.path else '',
+    }
+    
+    if not params['dbname']:
+        raise ValueError("Database name must be specified in URL")
+        
+    return params
 
 @dataclass
 class PostgresConfig(DatabaseConfig):
@@ -35,12 +67,64 @@ class PostgresConfig(DatabaseConfig):
         if db_config['type'] != 'postgres':
             raise ValueError(f"Configuration is not PostgreSQL type: {db_config['type']}")
 
+        # Check required credentials
+        if not db_config.get('user'):
+            raise ValueError("User must be specified in database configuration")
+        if not db_config.get('password'):
+            raise ValueError("Password must be specified in database configuration")
+
+        # Get connection parameters
+        if 'jdbc_url' in db_config:
+            # Parse JDBC URL for connection parameters
+            params = parse_jdbc_url(db_config['jdbc_url'])
+            config = cls(
+                dbname=params['dbname'],
+                user=db_config['user'],
+                password=db_config['password'],
+                host=params['host'],
+                port=params['port'],
+                local_host=local_host,
+            )
+        else:
+            if not db_config.get('dbname'):
+                raise ValueError("Database name must be specified in configuration")
+            if not db_config.get('host'):
+                raise ValueError("Host must be specified in configuration")
+            if not db_config.get('port'):
+                raise ValueError("Port must be specified in configuration")
+            config = cls(
+                dbname=db_config['dbname'],
+                user=db_config['user'],
+                password=db_config['password'],
+                host=db_config['host'],
+                port=str(db_config['port']),
+                local_host=local_host,
+            )
+        config.debug = cls.get_debug_mode()
+        return config
+
+    @classmethod
+    def from_jdbc_url(cls, jdbc_url: str, user: str, password: str, 
+                     local_host: Optional[str] = None) -> 'PostgresConfig':
+        """Create configuration from JDBC URL and credentials
+        
+        Args:
+            jdbc_url: JDBC URL (jdbc:postgresql://host:port/dbname)
+            user: Username for database connection
+            password: Password for database connection
+            local_host: Optional local host address
+            
+        Raises:
+            ValueError: If URL format is invalid or required parameters are missing
+        """
+        params = parse_jdbc_url(jdbc_url)
+        
         config = cls(
-            dbname=db_config.get('dbname', ''),
-            user=db_config.get('user', ''),
-            password=db_config.get('password', ''),
-            host=db_config.get('host', 'localhost'),
-            port=str(db_config.get('port', 5432)),
+            dbname=params['dbname'],
+            user=user,
+            password=password,
+            host=params['host'],
+            port=params['port'],
             local_host=local_host,
         )
         config.debug = cls.get_debug_mode()

--- a/tests/integration/test_postgres_config.py
+++ b/tests/integration/test_postgres_config.py
@@ -1,0 +1,129 @@
+"""Test PostgreSQL configuration functionality"""
+import pytest
+import tempfile
+import yaml
+from mcp_dbutils.postgres.config import PostgresConfig, parse_jdbc_url
+
+def test_parse_jdbc_url():
+    """Test JDBC URL parsing"""
+    # Test valid URL
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    params = parse_jdbc_url(url)
+    assert params["host"] == "localhost"
+    assert params["port"] == "5432"
+    assert params["dbname"] == "testdb"
+
+    # Test URL with credentials (should fail)
+    with pytest.raises(ValueError, match="should not contain credentials"):
+        parse_jdbc_url("jdbc:postgresql://user:pass@localhost:5432/testdb")
+
+    # Test invalid format
+    with pytest.raises(ValueError, match="Invalid PostgreSQL JDBC URL format"):
+        parse_jdbc_url("postgresql://localhost:5432/testdb")
+
+    # Test missing database name
+    with pytest.raises(ValueError, match="Database name must be specified"):
+        parse_jdbc_url("jdbc:postgresql://localhost:5432")
+
+def test_from_jdbc_url():
+    """Test PostgresConfig creation from JDBC URL"""
+    url = "jdbc:postgresql://localhost:5432/testdb"
+    config = PostgresConfig.from_jdbc_url(
+        url, 
+        user="test_user",
+        password="test_pass"
+    )
+
+    assert config.dbname == "testdb"
+    assert config.host == "localhost"
+    assert config.port == "5432"
+    assert config.user == "test_user"
+    assert config.password == "test_pass"
+    assert config.type == "postgres"
+
+def test_from_yaml_with_jdbc_url(tmp_path):
+    """Test PostgresConfig creation from YAML with JDBC URL"""
+    config_data = {
+        "databases": {
+            "test_db": {
+                "type": "postgres",
+                "jdbc_url": "jdbc:postgresql://localhost:5432/testdb",
+                "user": "test_user",
+                "password": "test_pass"
+            }
+        }
+    }
+
+    config_file = tmp_path / "config.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    config = PostgresConfig.from_yaml(str(config_file), "test_db")
+    assert config.dbname == "testdb"
+    assert config.host == "localhost"
+    assert config.port == "5432"
+    assert config.user == "test_user"
+    assert config.password == "test_pass"
+    assert config.type == "postgres"
+
+def test_required_fields_validation(tmp_path):
+    """Test validation of required configuration fields"""
+    # Missing user
+    config_data = {
+        "databases": {
+            "test_db": {
+                "type": "postgres",
+                "host": "localhost",
+                "port": 5432,
+                "dbname": "testdb",
+                "password": "test_pass"
+            }
+        }
+    }
+    
+    config_file = tmp_path / "config.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="User must be specified"):
+        PostgresConfig.from_yaml(str(config_file), "test_db")
+
+    # Missing password
+    config_data["databases"]["test_db"]["user"] = "test_user"
+    del config_data["databases"]["test_db"]["password"]
+    
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="Password must be specified"):
+        PostgresConfig.from_yaml(str(config_file), "test_db")
+
+    # Missing host
+    config_data["databases"]["test_db"]["password"] = "test_pass"
+    del config_data["databases"]["test_db"]["host"]
+    
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="Host must be specified"):
+        PostgresConfig.from_yaml(str(config_file), "test_db")
+
+    # Missing port
+    config_data["databases"]["test_db"]["host"] = "localhost"
+    del config_data["databases"]["test_db"]["port"]
+    
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="Port must be specified"):
+        PostgresConfig.from_yaml(str(config_file), "test_db")
+
+    # Missing database name
+    config_data["databases"]["test_db"]["port"] = 5432
+    del config_data["databases"]["test_db"]["dbname"]
+    
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="Database name must be specified"):
+        PostgresConfig.from_yaml(str(config_file), "test_db")


### PR DESCRIPTION
This PR implements JDBC URL support for PostgreSQL configuration.

## Changes
- Added JDBC URL parsing functionality with security measures
- Required credentials to be provided separately from URL
- Implemented validation for all required parameters
- Added comprehensive test coverage

## Testing
All tests passed:
- URL parsing tests
- Configuration validation tests
- Error handling tests
- Integration tests

Closes #2