### PR TITLE
Add SQLite JDBC URL documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,16 +143,31 @@ databases:
     user: postgres            # Credentials must be provided separately
     password: secret          # Not included in JDBC URL for security
 
-  # SQLite example (when using Docker)
+  # SQLite standard configuration
   my_sqlite:
     type: sqlite
-    path: /app/sqlite.db       # Mapped path inside container
+    path: /app/sqlite.db       # Database file path
     password: optional_password # optional
+
+  # SQLite with JDBC URL configuration
+  my_sqlite_jdbc:
+    type: sqlite
+    jdbc_url: jdbc:sqlite:/app/data.db?mode=ro&cache=shared  # Supports query parameters
+    password: optional_password    # Provided separately for security
 ```
 
-The configuration supports two formats for PostgreSQL:
+The configuration supports JDBC URL format for both PostgreSQL and SQLite:
+
+PostgreSQL:
 1. Standard configuration with individual parameters
-2. JDBC URL configuration with separate credentials (recommended for better compatibility)
+2. JDBC URL configuration with separate credentials
+
+SQLite:
+1. Standard configuration with path parameter
+2. JDBC URL configuration with query parameters support:
+   - mode=ro: Read-only mode
+   - cache=shared: Shared cache mode
+   - Other SQLite URI parameters
 
 ### Debug Mode
 Set environment variable `MCP_DEBUG=1` to enable debug mode for detailed logging output.

--- a/README_CN.md
+++ b/README_CN.md
@@ -127,16 +127,31 @@ databases:
     user: postgres            # 认证信息必须单独提供
     password: secret          # 出于安全考虑，不包含在JDBC URL中
 
-  # SQLite配置示例（使用Docker）
+  # SQLite标准配置
   my_sqlite:
     type: sqlite
-    path: /app/sqlite.db       # 容器内的映射路径
+    path: /app/sqlite.db       # 数据库文件路径
     password: optional_password # 可选
+
+  # SQLite JDBC URL配置
+  my_sqlite_jdbc:
+    type: sqlite
+    jdbc_url: jdbc:sqlite:/app/data.db?mode=ro&cache=shared  # 支持查询参数
+    password: optional_password    # 出于安全考虑单独提供
 ```
 
-PostgreSQL配置支持两种格式：
+PostgreSQL和SQLite都支持JDBC URL配置格式：
+
+PostgreSQL配置支持：
 1. 标准配置：使用独立的参数配置
-2. JDBC URL配置：使用JDBC URL并单独提供认证信息（推荐，兼容性更好）
+2. JDBC URL配置：使用JDBC URL并单独提供认证信息
+
+SQLite配置支持：
+1. 标准配置：使用path参数指定数据库文件
+2. JDBC URL配置：支持以下查询参数：
+   - mode=ro：只读模式
+   - cache=shared：共享缓存模式
+   - 其他SQLite URI参数
 
 ### 调试模式
 设置环境变量 `MCP_DEBUG=1` 启用调试模式，可以看到详细的日志输出。


### PR DESCRIPTION
This PR updates documentation to include SQLite JDBC URL support information.

## Changes
- Add SQLite JDBC URL configuration examples
- Add explanation of SQLite URL parameters
- Update configuration format description
- Keep English and Chinese documentation in sync

## Documentation Updates
- README.md:
  * Add SQLite JDBC URL examples
  * Document supported parameters
  * Update configuration section
- README_CN.md:
  * Add corresponding Chinese translations
  * Maintain consistency with English version

Part of #4