### PR TITLE
添加数据库类型到list_tables工具的返回信息

### DIFF
--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -247,6 +247,10 @@ class DatabaseServer:
             if name == "list_tables":
                 async with self.get_handler(database) as handler:
                     tables = await handler.get_tables()
+                    if not tables:
+                        # 空表列表的情况也返回数据库类型
+                        return [types.TextContent(type="text", text=f"[{handler.db_type}] No tables found")]
+                    
                     formatted_tables = "\n".join([
                         f"Table: {table.name}\n" +
                         f"URI: {table.uri}\n" +
@@ -254,7 +258,8 @@ class DatabaseServer:
                         "---"
                         for table in tables
                     ])
-                    return [types.TextContent(type="text", text=formatted_tables)]
+                    # 添加数据库类型前缀
+                    return [types.TextContent(type="text", text=f"[{handler.db_type}]\n{formatted_tables}")]
             elif name == "query":
                 sql = arguments.get("sql", "").strip()
                 if not sql:

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -50,12 +50,16 @@ async def test_list_tables_tool(postgres_db, sqlite_db, mcp_config):
                 result = await client.call_tool("list_tables", {"database": "test_pg"})
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
+                # 检查数据库类型前缀
+                assert "[postgres]" in result.content[0].text
                 assert "users" in result.content[0].text
 
                 # Test list_tables tool with SQLite
                 result = await client.call_tool("list_tables", {"database": "test_sqlite"})
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
+                # 检查数据库类型前缀
+                assert "[sqlite]" in result.content[0].text
                 assert "products" in result.content[0].text
 
         finally:


### PR DESCRIPTION
## 描述
添加数据库类型前缀到list_tables工具的返回结果中，使LLM能够知道当前操作的数据库类型，便于后续操作。

## 相关Issue
Fixes #9

## 实现方案
- 在list_tables工具的返回结果中添加数据库类型前缀，格式与错误信息保持一致，使用[数据库类型]前缀
- 处理空表列表的情况，也返回数据库类型信息
- 更新测试以验证返回结果中包含数据库类型前缀

## 测试步骤
- 运行 `uv run pytest tests/integration/test_tools.py -v` 验证测试通过

## 检查清单
- [x] 代码遵循项目编码规范
- [x] 添加了必要的测试
- [x] 所有测试通过