### PR TITLE
统一工具命名规范，添加dbutils前缀

### DIFF
--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -204,8 +204,8 @@ class DatabaseServer:
         async def handle_list_tools() -> list[types.Tool]:
             return [
                 types.Tool(
-                    name="query",
-                    description="Execute read-only SQL query",
+                    name="dbutils-run-query",
+                    description="Execute read-only SQL query on database",
                     inputSchema={
                         "type": "object",
                         "properties": {
@@ -222,7 +222,7 @@ class DatabaseServer:
                     }
                 ),
                 types.Tool(
-                    name="list_tables",
+                    name="dbutils-list-tables",
                     description="List all available tables in the specified database",
                     inputSchema={
                         "type": "object",
@@ -244,7 +244,7 @@ class DatabaseServer:
 
             database = arguments["database"]
 
-            if name == "list_tables":
+            if name == "dbutils-list-tables":
                 async with self.get_handler(database) as handler:
                     tables = await handler.get_tables()
                     if not tables:
@@ -260,7 +260,7 @@ class DatabaseServer:
                     ])
                     # 添加数据库类型前缀
                     return [types.TextContent(type="text", text=f"[{handler.db_type}]\n{formatted_tables}")]
-            elif name == "query":
+            elif name == "dbutils-run-query":
                 sql = arguments.get("sql", "").strip()
                 if not sql:
                     raise ConfigurationError("SQL query cannot be empty")

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -43,11 +43,11 @@ async def test_list_tables_tool(postgres_db, sqlite_db, mcp_config):
                 # List available tools
                 response = await client.list_tools()
                 tool_names = [tool.name for tool in response.tools]
-                assert "list_tables" in tool_names
-                assert "query" in tool_names
+                assert "dbutils-list-tables" in tool_names
+                assert "dbutils-run-query" in tool_names
 
                 # Test list_tables tool with PostgreSQL
-                result = await client.call_tool("list_tables", {"database": "test_pg"})
+                result = await client.call_tool("dbutils-list-tables", {"database": "test_pg"})
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
                 # 检查数据库类型前缀
@@ -55,7 +55,7 @@ async def test_list_tables_tool(postgres_db, sqlite_db, mcp_config):
                 assert "users" in result.content[0].text
 
                 # Test list_tables tool with SQLite
-                result = await client.call_tool("list_tables", {"database": "test_sqlite"})
+                result = await client.call_tool("dbutils-list-tables", {"database": "test_sqlite"})
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
                 # 检查数据库类型前缀


### PR DESCRIPTION
## 描述
为了使工具名称更加规范和清晰，给所有工具添加dbutils前缀：

- query -> dbutils-run-query
- list_tables -> dbutils-list-tables

## 相关Issue
Fixes #11

## 实现方案
- 修改list_tools中工具的定义，添加dbutils前缀
- 更新call_tool中的工具名称判断
- 更新相关测试用例

## 改动目的
- 让工具名称明确表明来源于dbutils服务
- 避免与其他MCP服务的工具名称冲突
- 保持命名规范的统一性

## 测试步骤
- 运行 `uv run pytest tests/integration/test_tools.py -v` 验证测试通过

## 检查清单
- [x] 代码遵循项目编码规范
- [x] 修改了相关测试
- [x] 所有测试通过