### PR TITLE
Rename 'database' to 'connection' for better clarity

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ Add to Claude configuration:
 The project requires a YAML configuration file, specified via the `--config` parameter. Configuration example:
 
 ```yaml
-databases:
+connections:
   # Standard PostgreSQL configuration example
   my_postgres:
     type: postgres
@@ -235,7 +235,7 @@ The abstraction layer design is the core architectural concept in MCP Database U
 
 ### Basic Query
 ```python
-# Access through database name
+# Access through connection name
 async with server.get_handler("my_postgres") as handler:
     # Execute SQL query
     result = await handler.execute_query("SELECT * FROM users")
@@ -253,7 +253,7 @@ schema = await handler.get_schema("users")
 ### Error Handling
 ```python
 try:
-    async with server.get_handler("my_db") as handler:
+    async with server.get_handler("my_connection") as handler:
         result = await handler.execute_query("SELECT * FROM users")
 except ValueError as e:
     print(f"Configuration error: {e}")
@@ -279,47 +279,47 @@ Core server class providing:
 #### dbutils-list-tables
 Lists all tables in the specified database.
 - Parameters:
-  * database: Database configuration name
+  * connection: Database connection name
 - Returns: Text content with a list of table names
 
 #### dbutils-run-query
 Executes a SQL query on the specified database.
 - Parameters:
-  * database: Database configuration name
+  * connection: Database connection name
   * sql: SQL query to execute (SELECT only)
 - Returns: Query results in a formatted text
 
 #### dbutils-get-stats
 Get table statistics information.
 - Parameters:
-  * database: Database configuration name
+  * connection: Database connection name
   * table: Table name
 - Returns: Statistics including row count, size, column stats
 
 #### dbutils-list-constraints
 List table constraints (primary key, foreign keys, etc).
 - Parameters:
-  * database: Database configuration name
+  * connection: Database connection name
   * table: Table name
 - Returns: Detailed constraint information
 
 #### dbutils-explain-query
 Get query execution plan with cost estimates.
 - Parameters:
-  * database: Database configuration name
+  * connection: Database connection name
   * sql: SQL query to explain
 - Returns: Formatted execution plan
 
 #### dbutils-get-performance
 Get database performance statistics.
 - Parameters:
-  * database: Database configuration name
+  * connection: Database connection name
 - Returns: Detailed performance statistics including query times, query types, error rates, and resource usage
 
 #### dbutils-analyze-query
 Analyze a SQL query for performance and provide optimization suggestions.
 - Parameters:
-  * database: Database configuration name
+  * connection: Database connection name
   * sql: SQL query to analyze
 - Returns: Query analysis with execution plan, timing information, and optimization suggestions
 

--- a/README_CN.md
+++ b/README_CN.md
@@ -110,7 +110,7 @@ docker run -i --rm \
 项目运行需要一个YAML格式的配置文件，通过 `--config` 参数指定路径。配置示例：
 
 ```yaml
-databases:
+connections:
   # PostgreSQL标准配置示例
   my_postgres:
     type: postgres
@@ -219,7 +219,7 @@ graph TD
 
 ### 基本查询
 ```python
-# 通过数据库名称访问
+# 通过连接名称访问
 async with server.get_handler("my_postgres") as handler:
     # 执行SQL查询
     result = await handler.execute_query("SELECT * FROM users")
@@ -237,7 +237,7 @@ schema = await handler.get_schema("users")
 ### 错误处理
 ```python
 try:
-    async with server.get_handler("my_db") as handler:
+    async with server.get_handler("my_connection") as handler:
         result = await handler.execute_query("SELECT * FROM users")
 except ValueError as e:
     print(f"配置错误: {e}")
@@ -263,47 +263,47 @@ except Exception as e:
 #### dbutils-list-tables
 列出指定数据库中的所有表。
 - 参数：
-  * database: 数据库配置名称
+  * connection: 数据库连接名称
 - 返回：包含表名列表的文本内容
 
 #### dbutils-run-query
 在指定数据库上执行SQL查询。
 - 参数：
-  * database: 数据库配置名称
+  * connection: 数据库连接名称
   * sql: 要执行的SQL查询（仅支持SELECT）
 - 返回：格式化的查询结果文本
 
 #### dbutils-get-stats
 获取表的统计信息。
 - 参数：
-  * database: 数据库配置名称
+  * connection: 数据库连接名称
   * table: 表名
 - 返回：包括行数、大小、列统计等信息
 
 #### dbutils-list-constraints
 列出表的约束信息（主键、外键等）。
 - 参数：
-  * database: 数据库配置名称
+  * connection: 数据库连接名称
   * table: 表名
 - 返回：详细的约束信息
 
 #### dbutils-explain-query
 获取查询的执行计划和成本估算。
 - 参数：
-  * database: 数据库配置名称
+  * connection: 数据库连接名称
   * sql: 要分析的SQL查询
 - 返回：格式化的执行计划
 
 #### dbutils-get-performance
 获取数据库性能统计信息。
 - 参数：
-  * database: 数据库配置名称
+  * connection: 数据库连接名称
 - 返回：详细的性能统计信息，包括查询时间、查询类型、错误率和资源使用情况
 
 #### dbutils-analyze-query
 分析SQL查询的性能并提供优化建议。
 - 参数：
-  * database: 数据库配置名称
+  * connection: 数据库连接名称
   * sql: 要分析的SQL查询
 - 返回：查询分析结果，包括执行计划、时间信息和优化建议
 

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,4 +1,4 @@
-databases:
+connections:
   # SQLite configuration examples
   # SQLite with standard configuration
   dev-db:

--- a/src/mcp_dbutils/__init__.py
+++ b/src/mcp_dbutils/__init__.py
@@ -1,4 +1,4 @@
-"""MCP Database Utilities Service"""
+"""MCP Connection Utilities Service"""
 
 import asyncio
 import argparse
@@ -9,7 +9,7 @@ import yaml
 from importlib.metadata import metadata
 
 from .log import create_logger
-from .base import DatabaseServer
+from .base import ConnectionServer
 
 # 获取包信息
 pkg_meta = metadata("mcp-dbutils")
@@ -19,7 +19,7 @@ log = create_logger(pkg_meta["Name"])
 
 async def run_server():
     """服务器运行逻辑"""
-    parser = argparse.ArgumentParser(description='MCP Database Server')
+    parser = argparse.ArgumentParser(description='MCP Connection Server')
     parser.add_argument('--config', required=True, help='YAML配置文件路径')
     parser.add_argument('--local-host', help='本地主机地址')
 
@@ -32,7 +32,7 @@ async def run_server():
     global log
     log = create_logger(pkg_meta["Name"], debug)
 
-    log("info", f"MCP Database Utilities Service v{pkg_meta['Version']}")
+    log("info", f"MCP Connection Utilities Service v{pkg_meta['Version']}")
     if debug:
         log("debug", "Debug模式已开启")
 
@@ -40,11 +40,11 @@ async def run_server():
     try:
         with open(args.config, 'r') as f:
             config = yaml.safe_load(f)
-            if not config or 'databases' not in config:
-                log("error", "配置文件必须包含 databases 配置")
+            if not config or 'connections' not in config:
+                log("error", "配置文件必须包含 connections 配置")
                 sys.exit(1)
-            if not config['databases']:
-                log("error", "配置文件必须包含至少一个数据库配置")
+            if not config['connections']:
+                log("error", "配置文件必须包含至少一个连接配置")
                 sys.exit(1)
     except Exception as e:
         log("error", f"读取配置文件失败: {str(e)}")
@@ -52,7 +52,7 @@ async def run_server():
 
     # 创建并运行服务器
     try:
-        server = DatabaseServer(args.config, debug)
+        server = ConnectionServer(args.config, debug)
         await server.run()
     except KeyboardInterrupt:
         log("info", "服务器已停止")

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -44,7 +44,6 @@ class DatabaseHandler(ABC):
         """
         self.config_path = config_path
         self.connection = connection
-        self.database = connection  # Keep for backward compatibility
         self.debug = debug
         self.log = create_logger(f"{pkg_meta['Name']}.handler.{connection}", debug)
         self.stats = ResourceStats()
@@ -502,13 +501,9 @@ class DatabaseServer:
         @self.server.call_tool()
         async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent]:
             if "connection" not in arguments:
-                if "database" in arguments:
-                    # For backward compatibility
-                    connection = arguments["database"]
-                else:
-                    raise ConfigurationError("Database connection name must be specified")
-            else:
-                connection = arguments["connection"]
+                raise ConfigurationError("Connection name must be specified")
+            
+            connection = arguments["connection"]
 
             if name == "dbutils-list-tables":
                 async with self.get_handler(connection) as handler:

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -56,7 +56,7 @@ class ConnectionHandler(ABC):
 
     @abstractmethod
     async def get_tables(self) -> list[types.Resource]:
-        """Get list of table resources from database"""
+        """Get list of table resources from database connection"""
         pass
 
     @abstractmethod
@@ -323,7 +323,7 @@ class ConnectionServer:
             return [
                 types.Tool(
                     name="dbutils-run-query",
-                    description="Execute read-only SQL query on database",
+                    description="Execute read-only SQL query on database connection",
                     inputSchema={
                         "type": "object",
                         "properties": {
@@ -341,7 +341,7 @@ class ConnectionServer:
                 ),
                 types.Tool(
                     name="dbutils-list-tables",
-                    description="List all available tables in the specified database",
+                    description="List all available tables in the specified database connection",
                     inputSchema={
                         "type": "object",
                         "properties": {

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -253,10 +253,7 @@ class ConnectionServer:
         with open(self.config_path, 'r') as f:
             config = yaml.safe_load(f)
             if not config or 'connections' not in config:
-                if 'databases' in config:
-                    raise ConfigurationError("Configuration format has changed: Please rename 'databases' section to 'connections'")
-                else:
-                    raise ConfigurationError("Configuration file must contain 'connections' section")
+                raise ConfigurationError("Configuration file must contain 'connections' section")
             if connection not in config['connections']:
                 available_connections = list(config['connections'].keys())
                 raise ConfigurationError(f"Connection not found: {connection}. Available connections: {available_connections}")

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -271,11 +271,11 @@ class ConnectionServer:
                 db_type = db_config['type']
                 self.logger("debug", f"Creating handler for database type: {db_type}")
                 if db_type == 'sqlite':
-                    from .sqlite.handler import SqliteHandler
-                    handler = SqliteHandler(self.config_path, connection, self.debug)
+                    from .sqlite.handler import SQLiteHandler
+                    handler = SQLiteHandler(self.config_path, connection, self.debug)
                 elif db_type == 'postgres':
-                    from .postgres.handler import PostgresHandler
-                    handler = PostgresHandler(self.config_path, connection, self.debug)
+                    from .postgres.handler import PostgreSQLHandler
+                    handler = PostgreSQLHandler(self.config_path, connection, self.debug)
                 else:
                     raise ConfigurationError(f"Unsupported database type: {db_type}")
 

--- a/src/mcp_dbutils/config.py
+++ b/src/mcp_dbutils/config.py
@@ -39,19 +39,22 @@ class DatabaseConfig(ABC):
         with open(yaml_path, 'r', encoding='utf-8') as f:
             config = yaml.safe_load(f)
 
-        if not config or 'databases' not in config:
-            raise ValueError("Configuration file must contain 'databases' section")
+        if not config or 'connections' not in config:
+            if 'databases' in config:
+                raise ValueError("Configuration format has changed: Please rename 'databases' section to 'connections'")
+            else:
+                raise ValueError("Configuration file must contain 'connections' section")
 
         # Validate type field in each database configuration
-        databases = config['databases']
-        for db_name, db_config in databases.items():
+        connections = config['connections']
+        for conn_name, db_config in connections.items():
             if 'type' not in db_config:
-                raise ValueError(f"Database configuration {db_name} missing required 'type' field")
+                raise ValueError(f"Database configuration {conn_name} missing required 'type' field")
             db_type = db_config['type']
             if db_type not in ('sqlite', 'postgres'):
-                raise ValueError(f"Invalid type value in database configuration {db_name}: {db_type}")
+                raise ValueError(f"Invalid type value in database configuration {conn_name}: {db_type}")
 
-        return databases
+        return connections
 
     @classmethod
     def get_debug_mode(cls) -> bool:

--- a/src/mcp_dbutils/config.py
+++ b/src/mcp_dbutils/config.py
@@ -7,14 +7,14 @@ from dataclasses import dataclass, field
 from typing import Optional, Dict, Any, Literal
 from pathlib import Path
 
-# Supported database types
-DBType = Literal['sqlite', 'postgres']
+# Supported connection types
+ConnectionType = Literal['sqlite', 'postgres']
 
-class DatabaseConfig(ABC):
-    """Base class for database configuration"""
+class ConnectionConfig(ABC):
+    """Base class for connection configuration"""
 
     debug: bool = False
-    type: DBType  # Database type
+    type: ConnectionType  # Connection type
 
     @abstractmethod
     def get_connection_params(self) -> Dict[str, Any]:

--- a/src/mcp_dbutils/config.py
+++ b/src/mcp_dbutils/config.py
@@ -40,10 +40,7 @@ class ConnectionConfig(ABC):
             config = yaml.safe_load(f)
 
         if not config or 'connections' not in config:
-            if 'databases' in config:
-                raise ValueError("Configuration format has changed: Please rename 'databases' section to 'connections'")
-            else:
-                raise ValueError("Configuration file must contain 'connections' section")
+            raise ValueError("Configuration file must contain 'connections' section")
 
         # Validate type field in each database configuration
         connections = config['connections']

--- a/src/mcp_dbutils/postgres/__init__.py
+++ b/src/mcp_dbutils/postgres/__init__.py
@@ -1,6 +1,6 @@
 """PostgreSQL module"""
 
-from .handler import PostgresHandler
-from .config import PostgresConfig
+from .handler import PostgreSQLHandler
+from .config import PostgreSQLConfig
 
-__all__ = ['PostgresHandler', 'PostgresConfig']
+__all__ = ['PostgreSQLHandler', 'PostgreSQLConfig']

--- a/src/mcp_dbutils/postgres/config.py
+++ b/src/mcp_dbutils/postgres/config.py
@@ -2,7 +2,7 @@
 from dataclasses import dataclass
 from typing import Optional, Dict, Any, Literal
 from urllib.parse import urlparse
-from ..config import DatabaseConfig
+from ..config import ConnectionConfig
 
 def parse_jdbc_url(jdbc_url: str) -> Dict[str, str]:
     """Parse JDBC URL into connection parameters
@@ -36,7 +36,7 @@ def parse_jdbc_url(jdbc_url: str) -> Dict[str, str]:
     return params
 
 @dataclass
-class PostgresConfig(DatabaseConfig):
+class PostgreSQLConfig(ConnectionConfig):
     dbname: str
     user: str
     password: str
@@ -46,7 +46,7 @@ class PostgresConfig(DatabaseConfig):
     type: Literal['postgres'] = 'postgres'
 
     @classmethod
-    def from_yaml(cls, yaml_path: str, db_name: str, local_host: Optional[str] = None) -> 'PostgresConfig':
+    def from_yaml(cls, yaml_path: str, db_name: str, local_host: Optional[str] = None) -> 'PostgreSQLConfig':
         """Create configuration from YAML file
 
         Args:
@@ -105,7 +105,7 @@ class PostgresConfig(DatabaseConfig):
 
     @classmethod
     def from_jdbc_url(cls, jdbc_url: str, user: str, password: str, 
-                     local_host: Optional[str] = None) -> 'PostgresConfig':
+                     local_host: Optional[str] = None) -> 'PostgreSQLConfig':
         """Create configuration from JDBC URL and credentials
         
         Args:

--- a/src/mcp_dbutils/postgres/config.py
+++ b/src/mcp_dbutils/postgres/config.py
@@ -31,7 +31,7 @@ def parse_jdbc_url(jdbc_url: str) -> Dict[str, str]:
     }
     
     if not params['dbname']:
-        raise ValueError("Database name must be specified in URL")
+        raise ValueError("PostgreSQL database name must be specified in URL")
         
     return params
 
@@ -51,27 +51,27 @@ class PostgreSQLConfig(ConnectionConfig):
 
         Args:
             yaml_path: Path to YAML configuration file
-            db_name: Database configuration name to use
+            db_name: Connection configuration name to use
             local_host: Optional local host address
         """
         configs = cls.load_yaml_config(yaml_path)
         if not db_name:
-            raise ValueError("Database name must be specified")
+            raise ValueError("Connection name must be specified")
         if db_name not in configs:
             available_dbs = list(configs.keys())
-            raise ValueError(f"Database configuration not found: {db_name}. Available configurations: {available_dbs}")
+            raise ValueError(f"Connection configuration not found: {db_name}. Available configurations: {available_dbs}")
 
         db_config = configs[db_name]
         if 'type' not in db_config:
-            raise ValueError("Database configuration must include 'type' field")
+            raise ValueError("Connection configuration must include 'type' field")
         if db_config['type'] != 'postgres':
             raise ValueError(f"Configuration is not PostgreSQL type: {db_config['type']}")
 
         # Check required credentials
         if not db_config.get('user'):
-            raise ValueError("User must be specified in database configuration")
+            raise ValueError("User must be specified in connection configuration")
         if not db_config.get('password'):
-            raise ValueError("Password must be specified in database configuration")
+            raise ValueError("Password must be specified in connection configuration")
 
         # Get connection parameters
         if 'jdbc_url' in db_config:
@@ -87,11 +87,11 @@ class PostgreSQLConfig(ConnectionConfig):
             )
         else:
             if not db_config.get('dbname'):
-                raise ValueError("Database name must be specified in configuration")
+                raise ValueError("PostgreSQL database name must be specified in configuration")
             if not db_config.get('host'):
-                raise ValueError("Host must be specified in configuration")
+                raise ValueError("Host must be specified in connection configuration")
             if not db_config.get('port'):
-                raise ValueError("Port must be specified in configuration")
+                raise ValueError("Port must be specified in connection configuration")
             config = cls(
                 dbname=db_config['dbname'],
                 user=db_config['user'],
@@ -110,8 +110,8 @@ class PostgreSQLConfig(ConnectionConfig):
         
         Args:
             jdbc_url: JDBC URL (jdbc:postgresql://host:port/dbname)
-            user: Username for database connection
-            password: Password for database connection
+            user: Username for connection
+            password: Password for connection
             local_host: Optional local host address
             
         Raises:

--- a/src/mcp_dbutils/postgres/handler.py
+++ b/src/mcp_dbutils/postgres/handler.py
@@ -5,9 +5,9 @@ from psycopg2.pool import SimpleConnectionPool
 import mcp.types as types
 
 from ..base import ConnectionHandler, ConnectionHandlerError
-from .config import PostgresConfig
+from .config import PostgreSQLConfig
 
-class PostgresHandler(ConnectionHandler):
+class PostgreSQLHandler(ConnectionHandler):
     @property
     def db_type(self) -> str:
         return 'postgres'
@@ -21,7 +21,7 @@ class PostgresHandler(ConnectionHandler):
             debug: Enable debug mode
         """
         super().__init__(config_path, connection, debug)
-        self.config = PostgresConfig.from_yaml(config_path, connection)
+        self.config = PostgreSQLConfig.from_yaml(config_path, connection)
 
         # No connection pool creation during initialization
         masked_params = self.config.get_masked_connection_info()

--- a/src/mcp_dbutils/postgres/handler.py
+++ b/src/mcp_dbutils/postgres/handler.py
@@ -12,16 +12,16 @@ class PostgresHandler(DatabaseHandler):
     def db_type(self) -> str:
         return 'postgres'
 
-    def __init__(self, config_path: str, database: str, debug: bool = False):
+    def __init__(self, config_path: str, connection: str, debug: bool = False):
         """Initialize PostgreSQL handler
 
         Args:
             config_path: Path to configuration file
-            database: Database configuration name
+            connection: Database connection name
             debug: Enable debug mode
         """
-        super().__init__(config_path, database, debug)
-        self.config = PostgresConfig.from_yaml(config_path, database)
+        super().__init__(config_path, connection, debug)
+        self.config = PostgresConfig.from_yaml(config_path, connection)
 
         # No connection pool creation during initialization
         masked_params = self.config.get_masked_connection_info()
@@ -47,7 +47,7 @@ class PostgresHandler(DatabaseHandler):
                 tables = cur.fetchall()
                 return [
                     types.Resource(
-                        uri=f"postgres://{self.database}/{table[0]}/schema",
+                        uri=f"postgres://{self.connection}/{table[0]}/schema",
                         name=f"{table[0]} schema",
                         description=table[1] if table[1] else None,
                         mimeType="application/json"

--- a/src/mcp_dbutils/postgres/handler.py
+++ b/src/mcp_dbutils/postgres/handler.py
@@ -1,4 +1,4 @@
-"""PostgreSQL database handler implementation"""
+"""PostgreSQL connection handler implementation"""
 
 import psycopg2
 from psycopg2.pool import SimpleConnectionPool
@@ -25,7 +25,7 @@ class PostgresHandler(DatabaseHandler):
 
         # No connection pool creation during initialization
         masked_params = self.config.get_masked_connection_info()
-        self.log("debug", f"Configuring database with parameters: {masked_params}")
+        self.log("debug", f"Configuring connection with parameters: {masked_params}")
         self.pool = None
 
     async def get_tables(self) -> list[types.Resource]:

--- a/src/mcp_dbutils/postgres/handler.py
+++ b/src/mcp_dbutils/postgres/handler.py
@@ -214,7 +214,7 @@ class PostgreSQLHandler(ConnectionHandler):
                     description.extend(col_info)
                     description.append("")  # Empty line between columns
                 
-                return "\n".join(formatted_indexes)
+                return "\n".join(description)
                 
         except psycopg2.Error as e:
             error_msg = f"Failed to get index information: [Code: {e.pgcode}] {e.pgerror or str(e)}"

--- a/src/mcp_dbutils/postgres/handler.py
+++ b/src/mcp_dbutils/postgres/handler.py
@@ -4,10 +4,10 @@ import psycopg2
 from psycopg2.pool import SimpleConnectionPool
 import mcp.types as types
 
-from ..base import DatabaseHandler, DatabaseError
+from ..base import ConnectionHandler, ConnectionHandlerError
 from .config import PostgresConfig
 
-class PostgresHandler(DatabaseHandler):
+class PostgresHandler(ConnectionHandler):
     @property
     def db_type(self) -> str:
         return 'postgres'
@@ -54,9 +54,9 @@ class PostgresHandler(DatabaseHandler):
                     ) for table in tables
                 ]
         except psycopg2.Error as e:
-            error_msg = f"Failed to get table list: [Code: {e.pgcode}] {e.pgerror or str(e)}"
+            error_msg = f"Failed to get constraint information: [Code: {e.pgcode}] {e.pgerror or str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()
@@ -109,7 +109,7 @@ class PostgresHandler(DatabaseHandler):
         except psycopg2.Error as e:
             error_msg = f"Failed to read table schema: [Code: {e.pgcode}] {e.pgerror or str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()
@@ -144,7 +144,7 @@ class PostgresHandler(DatabaseHandler):
                     cur.execute("ROLLBACK")
         except psycopg2.Error as e:
             error_msg = f"[{self.db_type}] Query execution failed: [Code: {e.pgcode}] {e.pgerror or str(e)}"
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()
@@ -214,12 +214,12 @@ class PostgresHandler(DatabaseHandler):
                     description.extend(col_info)
                     description.append("")  # Empty line between columns
                 
-                return "\n".join(description)
+                return "\n".join(formatted_indexes)
                 
         except psycopg2.Error as e:
-            error_msg = f"Failed to get table description: [Code: {e.pgcode}] {e.pgerror or str(e)}"
+            error_msg = f"Failed to get index information: [Code: {e.pgcode}] {e.pgerror or str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()
@@ -316,7 +316,7 @@ class PostgresHandler(DatabaseHandler):
         except psycopg2.Error as e:
             error_msg = f"Failed to get table DDL: [Code: {e.pgcode}] {e.pgerror or str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()
@@ -385,7 +385,7 @@ class PostgresHandler(DatabaseHandler):
         except psycopg2.Error as e:
             error_msg = f"Failed to get index information: [Code: {e.pgcode}] {e.pgerror or str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()
@@ -463,7 +463,7 @@ class PostgresHandler(DatabaseHandler):
         except psycopg2.Error as e:
             error_msg = f"Failed to get table statistics: [Code: {e.pgcode}] {e.pgerror or str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()
@@ -530,7 +530,7 @@ class PostgresHandler(DatabaseHandler):
         except psycopg2.Error as e:
             error_msg = f"Failed to get constraint information: [Code: {e.pgcode}] {e.pgerror or str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()
@@ -576,7 +576,7 @@ class PostgresHandler(DatabaseHandler):
         except psycopg2.Error as e:
             error_msg = f"Failed to explain query: [Code: {e.pgcode}] {e.pgerror or str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
         finally:
             if conn:
                 conn.close()

--- a/src/mcp_dbutils/postgres/server.py
+++ b/src/mcp_dbutils/postgres/server.py
@@ -4,14 +4,14 @@ from psycopg2.pool import SimpleConnectionPool
 from typing import Optional, List
 import mcp.types as types
 from importlib.metadata import metadata
-from ..base import DatabaseServer
+from ..base import ConnectionServer
 from ..log import create_logger
-from .config import PostgresConfig
+from .config import PostgreSQLConfig
 
 # 获取包信息用于日志命名
 pkg_meta = metadata("mcp-dbutils")
-class PostgresServer(DatabaseServer):
-    def __init__(self, config: PostgresConfig, config_path: Optional[str] = None):
+class PostgreSQLServer(ConnectionServer):
+    def __init__(self, config: PostgreSQLConfig, config_path: Optional[str] = None):
         """初始化PostgreSQL服务器
         Args:
             config: 数据库配置
@@ -153,7 +153,7 @@ class PostgresServer(DatabaseServer):
         try:
             if connection and self.config_path:
                 # 使用指定的数据库连接
-                config = PostgresConfig.from_yaml(self.config_path, connection)
+                config = PostgreSQLConfig.from_yaml(self.config_path, connection)
                 conn_params = config.get_connection_params()
                 masked_params = config.get_masked_connection_info()
                 self.log("info", f"使用配置 {connection} 连接数据库: {masked_params}")

--- a/src/mcp_dbutils/postgres/server.py
+++ b/src/mcp_dbutils/postgres/server.py
@@ -32,9 +32,9 @@ class PostgresServer(DatabaseServer):
             self.log("info", "测试连接成功")
             # 创建连接池
             self.pool = SimpleConnectionPool(1, 5, **conn_params)
-            self.log("info", "数据库连接池创建成功")
+            self.log("info", "连接池创建成功")
         except psycopg2.Error as e:
-            self.log("error", f"数据库连接失败: [Code: {e.pgcode}] {e.pgerror or str(e)}")
+            self.log("error", f"连接失败: [Code: {e.pgcode}] {e.pgerror or str(e)}")
             raise
     async def list_resources(self) -> list[types.Resource]:
         """列出所有表资源"""
@@ -124,9 +124,9 @@ class PostgresServer(DatabaseServer):
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "database": {
+                        "connection": {
                             "type": "string",
-                            "description": "数据库配置名称（可选）"
+                            "description": "数据库连接名称（可选）"
                         },
                         "sql": {
                             "type": "string",
@@ -147,16 +147,16 @@ class PostgresServer(DatabaseServer):
         # 仅允许SELECT语句
         if not sql.lower().startswith("select"):
             raise ValueError("仅支持SELECT查询")
-        database = arguments.get("database")
+        connection = arguments.get("connection")
         use_pool = True
         conn = None
         try:
-            if database and self.config_path:
-                # 使用指定的数据库配置
-                config = PostgresConfig.from_yaml(self.config_path, database)
+            if connection and self.config_path:
+                # 使用指定的数据库连接
+                config = PostgresConfig.from_yaml(self.config_path, connection)
                 conn_params = config.get_connection_params()
                 masked_params = config.get_masked_connection_info()
-                self.log("info", f"使用配置 {database} 连接数据库: {masked_params}")
+                self.log("info", f"使用配置 {connection} 连接数据库: {masked_params}")
                 conn = psycopg2.connect(**conn_params)
                 use_pool = False
             else:
@@ -173,7 +173,7 @@ class PostgresServer(DatabaseServer):
                     formatted_results = [dict(zip(columns, row)) for row in results]
                     result_text = str({
                         'type': 'postgres',
-                        'config_name': database or 'default',
+                        'config_name': connection or 'default',
                         'query_result': {
                             'columns': columns,
                             'rows': formatted_results,
@@ -191,7 +191,7 @@ class PostgresServer(DatabaseServer):
                 error = f"查询执行失败: {str(e)}"
             error_msg = str({
                 'type': 'postgres',
-                'config_name': database or 'default',
+                'config_name': connection or 'default',
                 'error': error
             })
             self.log("error", error_msg)
@@ -205,5 +205,5 @@ class PostgresServer(DatabaseServer):
     async def cleanup(self):
         """清理资源"""
         if hasattr(self, 'pool'):
-            self.log("info", "关闭数据库连接池")
+            self.log("info", "关闭连接池")
             self.pool.closeall()

--- a/src/mcp_dbutils/sqlite/__init__.py
+++ b/src/mcp_dbutils/sqlite/__init__.py
@@ -1,6 +1,6 @@
 """SQLite module"""
 
-from .handler import SqliteHandler
-from .config import SqliteConfig
+from .handler import SQLiteHandler
+from .config import SQLiteConfig
 
-__all__ = ['SqliteHandler', 'SqliteConfig']
+__all__ = ['SQLiteHandler', 'SQLiteConfig']

--- a/src/mcp_dbutils/sqlite/config.py
+++ b/src/mcp_dbutils/sqlite/config.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Any, Optional, Literal
 from urllib.parse import urlparse, parse_qs
-from ..config import DatabaseConfig
+from ..config import ConnectionConfig
 
 def parse_jdbc_url(jdbc_url: str) -> Dict[str, str]:
     """Parse JDBC URL into connection parameters
@@ -48,14 +48,14 @@ def parse_jdbc_url(jdbc_url: str) -> Dict[str, str]:
     }
 
 @dataclass
-class SqliteConfig(DatabaseConfig):
+class SQLiteConfig(ConnectionConfig):
     path: str
     password: Optional[str] = None
     uri: bool = True  # Enable URI mode to support parameters like password
     type: Literal['sqlite'] = 'sqlite'
 
     @classmethod
-    def from_jdbc_url(cls, jdbc_url: str, password: Optional[str] = None) -> 'SqliteConfig':
+    def from_jdbc_url(cls, jdbc_url: str, password: Optional[str] = None) -> 'SQLiteConfig':
         """Create configuration from JDBC URL
 
         Args:
@@ -63,7 +63,7 @@ class SqliteConfig(DatabaseConfig):
             password: Optional password for database encryption
 
         Returns:
-            SqliteConfig instance
+            SQLiteConfig instance
 
         Raises:
             ValueError: If URL format is invalid
@@ -109,7 +109,7 @@ class SqliteConfig(DatabaseConfig):
         return info
 
     @classmethod
-    def from_yaml(cls, yaml_path: str, db_name: str, **kwargs) -> 'SqliteConfig':
+    def from_yaml(cls, yaml_path: str, db_name: str, **kwargs) -> 'SQLiteConfig':
         """Create SQLite configuration from YAML
 
         Args:

--- a/src/mcp_dbutils/sqlite/config.py
+++ b/src/mcp_dbutils/sqlite/config.py
@@ -10,7 +10,7 @@ def parse_jdbc_url(jdbc_url: str) -> Dict[str, str]:
     """Parse JDBC URL into connection parameters
 
     Args:
-        jdbc_url: JDBC URL (e.g. jdbc:sqlite:file:/path/to/database.db or jdbc:sqlite:/path/to/database.db)
+        jdbc_url: JDBC URL (e.g. jdbc:sqlite:file:/path/to/sqlite.db or jdbc:sqlite:/path/to/sqlite.db)
 
     Returns:
         Dictionary of connection parameters
@@ -59,7 +59,7 @@ class SQLiteConfig(ConnectionConfig):
         """Create configuration from JDBC URL
 
         Args:
-            jdbc_url: JDBC URL (e.g. jdbc:sqlite:file:/path/to/database.db)
+            jdbc_url: JDBC URL (e.g. jdbc:sqlite:file:/path/to/sqlite.db)
             password: Optional password for database encryption
 
         Returns:

--- a/src/mcp_dbutils/sqlite/config.py
+++ b/src/mcp_dbutils/sqlite/config.py
@@ -40,7 +40,7 @@ def parse_jdbc_url(jdbc_url: str) -> Dict[str, str]:
             params[key] = values[0]
 
     if not path:
-        raise ValueError("Database path must be specified in URL")
+        raise ValueError("SQLite file path must be specified in URL")
 
     return {
         'path': path,
@@ -80,7 +80,7 @@ class SQLiteConfig(ConnectionConfig):
 
     @property
     def absolute_path(self) -> str:
-        """Return absolute path to database file"""
+        """Return absolute path to SQLite database file"""
         return str(Path(self.path).expanduser().resolve())
 
     def get_connection_params(self) -> Dict[str, Any]:
@@ -114,18 +114,18 @@ class SQLiteConfig(ConnectionConfig):
 
         Args:
             yaml_path: Path to YAML configuration file
-            db_name: Database configuration name
+            db_name: Connection configuration name
         """
         configs = cls.load_yaml_config(yaml_path)
 
         if db_name not in configs:
             available_dbs = list(configs.keys())
-            raise ValueError(f"Database configuration not found: {db_name}. Available configurations: {available_dbs}")
+            raise ValueError(f"Connection configuration not found: {db_name}. Available configurations: {available_dbs}")
 
         db_config = configs[db_name]
 
         if 'type' not in db_config:
-            raise ValueError("Database configuration must include 'type' field")
+            raise ValueError("Connection configuration must include 'type' field")
         if db_config['type'] != 'sqlite':
             raise ValueError(f"Configuration is not SQLite type: {db_config['type']}")
 

--- a/src/mcp_dbutils/sqlite/handler.py
+++ b/src/mcp_dbutils/sqlite/handler.py
@@ -1,14 +1,14 @@
-"""SQLite database handler implementation"""
+"""SQLite connection handler implementation"""
 
 import sqlite3
 import json
 from typing import Any
 import mcp.types as types
 
-from ..base import DatabaseHandler, DatabaseError
+from ..base import ConnectionHandler, ConnectionHandlerError
 from .config import SqliteConfig
 
-class SqliteHandler(DatabaseHandler):
+class SQLiteHandler(ConnectionHandler):
     @property
     def db_type(self) -> str:
         return 'sqlite'
@@ -41,7 +41,7 @@ class SqliteHandler(DatabaseHandler):
         except sqlite3.Error as e:
             error_msg = f"Failed to get table list: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def get_schema(self, table_name: str) -> str:
         """Get table schema information"""
@@ -70,14 +70,14 @@ class SqliteHandler(DatabaseHandler):
         except sqlite3.Error as e:
             error_msg = f"Failed to read table schema: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def _execute_query(self, sql: str) -> str:
         """Execute SQL query"""
         try:
             # Only allow SELECT statements
             if not sql.strip().upper().startswith("SELECT"):
-                raise DatabaseError("cannot execute DELETE statement")
+                raise ConnectionHandlerError("cannot execute DELETE statement")
             
             with sqlite3.connect(self.config.path) as conn:
                 conn.row_factory = sqlite3.Row
@@ -99,7 +99,7 @@ class SqliteHandler(DatabaseHandler):
                 return result_text
         except sqlite3.Error as e:
             error_msg = f"[{self.db_type}] Query execution failed: {str(e)}"
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def get_table_description(self, table_name: str) -> str:
         """Get detailed table description"""
@@ -131,7 +131,7 @@ class SqliteHandler(DatabaseHandler):
         except sqlite3.Error as e:
             error_msg = f"Failed to get table description: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def get_table_ddl(self, table_name: str) -> str:
         """Get DDL statement for creating table"""
@@ -163,7 +163,7 @@ class SqliteHandler(DatabaseHandler):
         except sqlite3.Error as e:
             error_msg = f"Failed to get table DDL: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def get_table_indexes(self, table_name: str) -> str:
         """Get index information for table"""
@@ -210,7 +210,7 @@ class SqliteHandler(DatabaseHandler):
         except sqlite3.Error as e:
             error_msg = f"Failed to get index information: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def get_table_stats(self, table_name: str) -> str:
         """Get table statistics information"""
@@ -291,7 +291,7 @@ class SqliteHandler(DatabaseHandler):
         except sqlite3.Error as e:
             error_msg = f"Failed to get table statistics: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def get_table_constraints(self, table_name: str) -> str:
         """Get constraint information for table"""
@@ -371,7 +371,7 @@ class SqliteHandler(DatabaseHandler):
         except sqlite3.Error as e:
             error_msg = f"Failed to get constraint information: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def explain_query(self, sql: str) -> str:
         """Get query execution plan"""
@@ -409,7 +409,7 @@ class SqliteHandler(DatabaseHandler):
         except sqlite3.Error as e:
             error_msg = f"Failed to explain query: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
-            raise DatabaseError(error_msg)
+            raise ConnectionHandlerError(error_msg)
 
     async def cleanup(self):
         """Cleanup resources"""

--- a/src/mcp_dbutils/sqlite/handler.py
+++ b/src/mcp_dbutils/sqlite/handler.py
@@ -6,7 +6,7 @@ from typing import Any
 import mcp.types as types
 
 from ..base import ConnectionHandler, ConnectionHandlerError
-from .config import SqliteConfig
+from .config import SQLiteConfig
 
 class SQLiteHandler(ConnectionHandler):
     @property
@@ -22,7 +22,7 @@ class SQLiteHandler(ConnectionHandler):
             debug: Enable debug mode
         """
         super().__init__(config_path, connection, debug)
-        self.config = SqliteConfig.from_yaml(config_path, connection)
+        self.config = SQLiteConfig.from_yaml(config_path, connection)
 
     async def get_tables(self) -> list[types.Resource]:
         """Get all table resources"""

--- a/src/mcp_dbutils/sqlite/handler.py
+++ b/src/mcp_dbutils/sqlite/handler.py
@@ -13,16 +13,16 @@ class SqliteHandler(DatabaseHandler):
     def db_type(self) -> str:
         return 'sqlite'
 
-    def __init__(self, config_path: str, database: str, debug: bool = False):
+    def __init__(self, config_path: str, connection: str, debug: bool = False):
         """Initialize SQLite handler
 
         Args:
             config_path: Path to configuration file
-            database: Database configuration name
+            connection: Database connection name
             debug: Enable debug mode
         """
-        super().__init__(config_path, database, debug)
-        self.config = SqliteConfig.from_yaml(config_path, database)
+        super().__init__(config_path, connection, debug)
+        self.config = SqliteConfig.from_yaml(config_path, connection)
 
     async def get_tables(self) -> list[types.Resource]:
         """Get all table resources"""
@@ -33,7 +33,7 @@ class SqliteHandler(DatabaseHandler):
                 tables = cur.fetchall()
                 return [
                     types.Resource(
-                        uri=f"sqlite://{self.database}/{table[0]}/schema",
+                        uri=f"sqlite://{self.connection}/{table[0]}/schema",
                         name=f"{table[0]} schema",
                         mimeType="application/json"
                     ) for table in tables

--- a/src/mcp_dbutils/sqlite/server.py
+++ b/src/mcp_dbutils/sqlite/server.py
@@ -7,15 +7,15 @@ from typing import Optional, List
 import mcp.types as types
 from importlib.metadata import metadata
 
-from ..base import DatabaseServer
+from ..base import ConnectionServer
 from ..log import create_logger
-from .config import SqliteConfig
+from .config import SQLiteConfig
 
 # 获取包信息用于日志命名
 pkg_meta = metadata("mcp-dbutils")
 
-class SqliteServer(DatabaseServer):
-    def __init__(self, config: SqliteConfig, config_path: Optional[str] = None):
+class SQLiteServer(ConnectionServer):
+    def __init__(self, config: SQLiteConfig, config_path: Optional[str] = None):
         """初始化 SQLite 服务器
 
         Args:
@@ -56,7 +56,7 @@ class SqliteServer(DatabaseServer):
             connection = arguments.get("connection")
             if connection and self.config_path:
                 # 使用指定的数据库连接
-                config = SqliteConfig.from_yaml(self.config_path, connection)
+                config = SQLiteConfig.from_yaml(self.config_path, connection)
                 connection_params = config.get_connection_params()
                 masked_params = config.get_masked_connection_info()
                 self.log("info", f"使用配置 {connection} 连接: {masked_params}")
@@ -159,7 +159,7 @@ class SqliteServer(DatabaseServer):
             connection = arguments.get("connection")
             if connection and self.config_path:
                 # 使用指定的数据库连接
-                config = SqliteConfig.from_yaml(self.config_path, connection)
+                config = SQLiteConfig.from_yaml(self.config_path, connection)
                 connection_params = config.get_connection_params()
                 masked_params = config.get_masked_connection_info()
                 self.log("info", f"使用配置 {connection} 连接: {masked_params}")

--- a/src/mcp_dbutils/sqlite/server.py
+++ b/src/mcp_dbutils/sqlite/server.py
@@ -32,13 +32,13 @@ class SqliteServer(DatabaseServer):
 
         # 测试连接
         try:
-            self.log("debug", f"正在连接数据库: {self.config.get_masked_connection_info()}")
+            self.log("debug", f"正在连接: {self.config.get_masked_connection_info()}")
             connection_params = self.config.get_connection_params()
             with closing(sqlite3.connect(**connection_params)) as conn:
                 conn.row_factory = sqlite3.Row
-            self.log("info", "数据库连接测试成功")
+            self.log("info", "连接测试成功")
         except sqlite3.Error as e:
-            self.log("error", f"数据库连接失败: {str(e)}")
+            self.log("error", f"连接失败: {str(e)}")
             raise
 
     def _get_connection(self):
@@ -53,13 +53,13 @@ class SqliteServer(DatabaseServer):
         use_default = True
         conn = None
         try:
-            database = arguments.get("database")
-            if database and self.config_path:
-                # 使用指定的数据库配置
-                config = SqliteConfig.from_yaml(self.config_path, database)
+            connection = arguments.get("connection")
+            if connection and self.config_path:
+                # 使用指定的数据库连接
+                config = SqliteConfig.from_yaml(self.config_path, connection)
                 connection_params = config.get_connection_params()
                 masked_params = config.get_masked_connection_info()
-                self.log("info", f"使用配置 {database} 连接数据库: {masked_params}")
+                self.log("info", f"使用配置 {connection} 连接: {masked_params}")
                 conn = sqlite3.connect(**connection_params)
                 conn.row_factory = sqlite3.Row
                 use_default = False
@@ -126,9 +126,9 @@ class SqliteServer(DatabaseServer):
                 inputSchema={
                     "type": "object",
                     "properties": {
-                        "database": {
+                        "connection": {
                             "type": "string",
-                            "description": "数据库配置名称（可选）"
+                            "description": "数据库连接名称（可选）"
                         },
                         "sql": {
                             "type": "string",
@@ -156,13 +156,13 @@ class SqliteServer(DatabaseServer):
         use_default = True
         conn = None
         try:
-            database = arguments.get("database")
-            if database and self.config_path:
-                # 使用指定的数据库配置
-                config = SqliteConfig.from_yaml(self.config_path, database)
+            connection = arguments.get("connection")
+            if connection and self.config_path:
+                # 使用指定的数据库连接
+                config = SqliteConfig.from_yaml(self.config_path, connection)
                 connection_params = config.get_connection_params()
                 masked_params = config.get_masked_connection_info()
-                self.log("info", f"使用配置 {database} 连接数据库: {masked_params}")
+                self.log("info", f"使用配置 {connection} 连接: {masked_params}")
                 conn = sqlite3.connect(**connection_params)
                 conn.row_factory = sqlite3.Row
                 use_default = False
@@ -180,7 +180,7 @@ class SqliteServer(DatabaseServer):
 
                 result_text = str({
                     'type': 'sqlite',
-                    'config_name': database or 'default',
+                    'config_name': connection or 'default',
                     'query_result': {
                         'columns': columns,
                         'rows': formatted_results,
@@ -194,7 +194,7 @@ class SqliteServer(DatabaseServer):
         except sqlite3.Error as e:
             error_msg = str({
                 'type': 'sqlite',
-                'config_name': database or 'default',
+                'config_name': connection or 'default',
                 'error': f"查询执行失败: {str(e)}"
             })
             self.log("error", error_msg)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -116,7 +116,7 @@ async def mcp_config(postgres_db, sqlite_db) -> Dict:
     Generate MCP server configuration for testing.
     """
     return {
-        "databases": {
+        "connections": {
             "test_pg": postgres_db,
             "test_sqlite": sqlite_db
         }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -82,7 +82,7 @@ async def sqlite_db() -> AsyncGenerator[Dict[str, str], None]:
     with tempfile.NamedTemporaryFile(suffix='.db', delete=False) as tmp:
         db_path = Path(tmp.name)
 
-        # Create test database and data
+        # Create test database file and data
         async with aiosqlite.connect(db_path) as db:
             await db.execute("""
                 CREATE TABLE products (

--- a/tests/integration/test_monitoring.py
+++ b/tests/integration/test_monitoring.py
@@ -3,7 +3,7 @@
 import pytest
 import tempfile
 import yaml
-from mcp_dbutils.base import ConnectionServer, ConnectionError
+from mcp_dbutils.base import ConnectionServer, ConnectionHandlerError
 
 @pytest.mark.asyncio
 async def test_sqlite_monitoring(sqlite_db, mcp_config):
@@ -29,11 +29,11 @@ async def test_sqlite_monitoring(sqlite_db, mcp_config):
             # Test error recording
             try:
                 await handler.execute_query("SELECT * FROM nonexistent")
-            except ConnectionError:
+            except ConnectionHandlerError:
                 pass
 
             assert stats.error_count == 1
-            assert "ConnectionError" in stats.error_types
+            assert "ConnectionHandlerError" in stats.error_types
 
         # After context exit, connection should be closed
         assert stats.active_connections == 0
@@ -62,11 +62,11 @@ async def test_postgres_monitoring(postgres_db, mcp_config):
             # Test error recording
             try:
                 await handler.execute_query("SELECT * FROM nonexistent")
-            except ConnectionError:
+            except ConnectionHandlerError:
                 pass
 
             assert stats.error_count == 1
-            assert "ConnectionError" in stats.error_types
+            assert "ConnectionHandlerError" in stats.error_types
 
             # Test stats serialization
             stats_dict = stats.to_dict()

--- a/tests/integration/test_monitoring.py
+++ b/tests/integration/test_monitoring.py
@@ -3,7 +3,7 @@
 import pytest
 import tempfile
 import yaml
-from mcp_dbutils.base import DatabaseServer, DatabaseError
+from mcp_dbutils.base import ConnectionServer, ConnectionError
 
 @pytest.mark.asyncio
 async def test_sqlite_monitoring(sqlite_db, mcp_config):
@@ -11,7 +11,7 @@ async def test_sqlite_monitoring(sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         async with server.get_handler("test_sqlite") as handler:
             # Connection stats
@@ -29,11 +29,11 @@ async def test_sqlite_monitoring(sqlite_db, mcp_config):
             # Test error recording
             try:
                 await handler.execute_query("SELECT * FROM nonexistent")
-            except DatabaseError:
+            except ConnectionError:
                 pass
 
             assert stats.error_count == 1
-            assert "DatabaseError" in stats.error_types
+            assert "ConnectionError" in stats.error_types
 
         # After context exit, connection should be closed
         assert stats.active_connections == 0
@@ -44,7 +44,7 @@ async def test_postgres_monitoring(postgres_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         async with server.get_handler("test_pg") as handler:
             # Connection stats
@@ -62,11 +62,11 @@ async def test_postgres_monitoring(postgres_db, mcp_config):
             # Test error recording
             try:
                 await handler.execute_query("SELECT * FROM nonexistent")
-            except DatabaseError:
+            except ConnectionError:
                 pass
 
             assert stats.error_count == 1
-            assert "DatabaseError" in stats.error_types
+            assert "ConnectionError" in stats.error_types
 
             # Test stats serialization
             stats_dict = stats.to_dict()

--- a/tests/integration/test_monitoring_enhanced.py
+++ b/tests/integration/test_monitoring_enhanced.py
@@ -6,7 +6,7 @@ import yaml
 import time
 import json
 from datetime import datetime
-from mcp_dbutils.base import DatabaseServer, DatabaseError
+from mcp_dbutils.base import ConnectionServer, ConnectionError
 from mcp_dbutils.stats import ResourceStats
 
 @pytest.mark.asyncio
@@ -49,7 +49,7 @@ async def test_query_duration_tracking(sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         async with server.get_handler("test_sqlite") as handler:
             # Execute a query and check duration tracking
@@ -82,7 +82,7 @@ async def test_get_performance_stats(sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
         
         # Execute some queries to generate stats
         async with server.get_handler("test_sqlite") as handler:
@@ -92,7 +92,7 @@ async def test_get_performance_stats(sqlite_db, mcp_config):
             # Intentionally cause an error
             try:
                 await handler.execute_query("SELECT * FROM nonexistent")
-            except DatabaseError:
+            except ConnectionError:
                 pass
             
             # Get performance stats directly from handler
@@ -111,7 +111,7 @@ async def test_get_performance_stats(sqlite_db, mcp_config):
             
             # Verify error tracking
             assert handler.stats.error_count == 1
-            assert "DatabaseError" in handler.stats.error_types
+            assert "ConnectionError" in handler.stats.error_types
 
 @pytest.mark.asyncio
 async def test_query_analysis(sqlite_db, mcp_config):
@@ -119,7 +119,7 @@ async def test_query_analysis(sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
         
         async with server.get_handler("test_sqlite") as handler:
             # Get execution plan

--- a/tests/integration/test_monitoring_enhanced.py
+++ b/tests/integration/test_monitoring_enhanced.py
@@ -6,7 +6,7 @@ import yaml
 import time
 import json
 from datetime import datetime
-from mcp_dbutils.base import ConnectionServer, ConnectionError
+from mcp_dbutils.base import ConnectionServer, ConnectionHandlerError
 from mcp_dbutils.stats import ResourceStats
 
 @pytest.mark.asyncio
@@ -92,7 +92,7 @@ async def test_get_performance_stats(sqlite_db, mcp_config):
             # Intentionally cause an error
             try:
                 await handler.execute_query("SELECT * FROM nonexistent")
-            except ConnectionError:
+            except ConnectionHandlerError:
                 pass
             
             # Get performance stats directly from handler
@@ -111,7 +111,7 @@ async def test_get_performance_stats(sqlite_db, mcp_config):
             
             # Verify error tracking
             assert handler.stats.error_count == 1
-            assert "ConnectionError" in handler.stats.error_types
+            assert "ConnectionHandlerError" in handler.stats.error_types
 
 @pytest.mark.asyncio
 async def test_query_analysis(sqlite_db, mcp_config):

--- a/tests/integration/test_postgres.py
+++ b/tests/integration/test_postgres.py
@@ -1,7 +1,7 @@
 import pytest
 import tempfile
 import yaml
-from mcp_dbutils.base import DatabaseServer, ConfigurationError, DatabaseError
+from mcp_dbutils.base import ConnectionServer, ConfigurationError, ConnectionHandlerError
 from mcp_dbutils.log import create_logger
 
 # 创建测试用的 logger
@@ -15,7 +15,7 @@ async def test_list_tables(postgres_db, mcp_config):
         logger("debug", f"PostgreSQL config: {config_data}")
         yaml.dump(config_data, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
         async with server.get_handler("test_pg") as handler:
             tables = await handler.get_tables()
             table_names = [table.name.replace(" schema", "") for table in tables]
@@ -37,7 +37,7 @@ async def test_execute_query(postgres_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
         async with server.get_handler("test_pg") as handler:
                 # Simple SELECT
                 result_str = await handler.execute_query("SELECT name FROM users ORDER BY name")
@@ -60,9 +60,9 @@ async def test_non_select_query(postgres_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
         async with server.get_handler("test_pg") as handler:
-            with pytest.raises(DatabaseError, match="cannot execute DELETE in a read-only transaction"):
+            with pytest.raises(ConnectionHandlerError, match="cannot execute DELETE in a read-only transaction"):
                 await handler.execute_query("DELETE FROM users")
 
 @pytest.mark.asyncio
@@ -71,9 +71,9 @@ async def test_invalid_query(postgres_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
         async with server.get_handler("test_pg") as handler:
-            with pytest.raises(DatabaseError):
+            with pytest.raises(ConnectionHandlerError):
                 await handler.execute_query("SELECT * FROM nonexistent_table")
 
 @pytest.mark.asyncio
@@ -82,6 +82,6 @@ async def test_connection_cleanup(postgres_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
         async with server.get_handler("test_pg") as handler:
             await handler.get_tables()

--- a/tests/integration/test_postgres_config.py
+++ b/tests/integration/test_postgres_config.py
@@ -22,7 +22,7 @@ def test_parse_jdbc_url():
         parse_jdbc_url("postgresql://localhost:5432/testdb")
 
     # Test missing database name
-    with pytest.raises(ValueError, match="Database name must be specified"):
+    with pytest.raises(ValueError, match="PostgreSQL database name must be specified"):
         parse_jdbc_url("jdbc:postgresql://localhost:5432")
 
 def test_from_jdbc_url():
@@ -85,7 +85,7 @@ def test_required_fields_validation(tmp_path):
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
 
-    with pytest.raises(ValueError, match="User must be specified"):
+    with pytest.raises(ValueError, match="User must be specified in connection"):
         PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
     # Missing password
@@ -95,7 +95,7 @@ def test_required_fields_validation(tmp_path):
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
 
-    with pytest.raises(ValueError, match="Password must be specified"):
+    with pytest.raises(ValueError, match="Password must be specified in connection"):
         PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
     # Missing host
@@ -105,7 +105,7 @@ def test_required_fields_validation(tmp_path):
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
 
-    with pytest.raises(ValueError, match="Host must be specified"):
+    with pytest.raises(ValueError, match="Host must be specified in connection"):
         PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
     # Missing port
@@ -115,7 +115,7 @@ def test_required_fields_validation(tmp_path):
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
 
-    with pytest.raises(ValueError, match="Port must be specified"):
+    with pytest.raises(ValueError, match="Port must be specified in connection"):
         PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
     # Missing database name
@@ -125,5 +125,5 @@ def test_required_fields_validation(tmp_path):
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
 
-    with pytest.raises(ValueError, match="Database name must be specified"):
+    with pytest.raises(ValueError, match="PostgreSQL database name must be specified"):
         PostgreSQLConfig.from_yaml(str(config_file), "test_db")

--- a/tests/integration/test_postgres_config.py
+++ b/tests/integration/test_postgres_config.py
@@ -44,7 +44,7 @@ def test_from_jdbc_url():
 def test_from_yaml_with_jdbc_url(tmp_path):
     """Test PostgresConfig creation from YAML with JDBC URL"""
     config_data = {
-        "databases": {
+        "connections": {
             "test_db": {
                 "type": "postgres",
                 "jdbc_url": "jdbc:postgresql://localhost:5432/testdb",
@@ -70,7 +70,7 @@ def test_required_fields_validation(tmp_path):
     """Test validation of required configuration fields"""
     # Missing user
     config_data = {
-        "databases": {
+        "connections": {
             "test_db": {
                 "type": "postgres",
                 "host": "localhost",
@@ -89,8 +89,8 @@ def test_required_fields_validation(tmp_path):
         PostgresConfig.from_yaml(str(config_file), "test_db")
 
     # Missing password
-    config_data["databases"]["test_db"]["user"] = "test_user"
-    del config_data["databases"]["test_db"]["password"]
+    config_data["connections"]["test_db"]["user"] = "test_user"
+    del config_data["connections"]["test_db"]["password"]
     
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
@@ -99,8 +99,8 @@ def test_required_fields_validation(tmp_path):
         PostgresConfig.from_yaml(str(config_file), "test_db")
 
     # Missing host
-    config_data["databases"]["test_db"]["password"] = "test_pass"
-    del config_data["databases"]["test_db"]["host"]
+    config_data["connections"]["test_db"]["password"] = "test_pass"
+    del config_data["connections"]["test_db"]["host"]
     
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
@@ -109,8 +109,8 @@ def test_required_fields_validation(tmp_path):
         PostgresConfig.from_yaml(str(config_file), "test_db")
 
     # Missing port
-    config_data["databases"]["test_db"]["host"] = "localhost"
-    del config_data["databases"]["test_db"]["port"]
+    config_data["connections"]["test_db"]["host"] = "localhost"
+    del config_data["connections"]["test_db"]["port"]
     
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
@@ -119,8 +119,8 @@ def test_required_fields_validation(tmp_path):
         PostgresConfig.from_yaml(str(config_file), "test_db")
 
     # Missing database name
-    config_data["databases"]["test_db"]["port"] = 5432
-    del config_data["databases"]["test_db"]["dbname"]
+    config_data["connections"]["test_db"]["port"] = 5432
+    del config_data["connections"]["test_db"]["dbname"]
     
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)

--- a/tests/integration/test_postgres_config.py
+++ b/tests/integration/test_postgres_config.py
@@ -2,7 +2,7 @@
 import pytest
 import tempfile
 import yaml
-from mcp_dbutils.postgres.config import PostgresConfig, parse_jdbc_url
+from mcp_dbutils.postgres.config import PostgreSQLConfig, parse_jdbc_url
 
 def test_parse_jdbc_url():
     """Test JDBC URL parsing"""
@@ -26,9 +26,9 @@ def test_parse_jdbc_url():
         parse_jdbc_url("jdbc:postgresql://localhost:5432")
 
 def test_from_jdbc_url():
-    """Test PostgresConfig creation from JDBC URL"""
+    """Test PostgreSQLConfig creation from JDBC URL"""
     url = "jdbc:postgresql://localhost:5432/testdb"
-    config = PostgresConfig.from_jdbc_url(
+    config = PostgreSQLConfig.from_jdbc_url(
         url, 
         user="test_user",
         password="test_pass"
@@ -42,7 +42,7 @@ def test_from_jdbc_url():
     assert config.type == "postgres"
 
 def test_from_yaml_with_jdbc_url(tmp_path):
-    """Test PostgresConfig creation from YAML with JDBC URL"""
+    """Test PostgreSQLConfig creation from YAML with JDBC URL"""
     config_data = {
         "connections": {
             "test_db": {
@@ -58,7 +58,7 @@ def test_from_yaml_with_jdbc_url(tmp_path):
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
 
-    config = PostgresConfig.from_yaml(str(config_file), "test_db")
+    config = PostgreSQLConfig.from_yaml(str(config_file), "test_db")
     assert config.dbname == "testdb"
     assert config.host == "localhost"
     assert config.port == "5432"
@@ -86,7 +86,7 @@ def test_required_fields_validation(tmp_path):
         yaml.dump(config_data, f)
 
     with pytest.raises(ValueError, match="User must be specified"):
-        PostgresConfig.from_yaml(str(config_file), "test_db")
+        PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
     # Missing password
     config_data["connections"]["test_db"]["user"] = "test_user"
@@ -96,7 +96,7 @@ def test_required_fields_validation(tmp_path):
         yaml.dump(config_data, f)
 
     with pytest.raises(ValueError, match="Password must be specified"):
-        PostgresConfig.from_yaml(str(config_file), "test_db")
+        PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
     # Missing host
     config_data["connections"]["test_db"]["password"] = "test_pass"
@@ -106,7 +106,7 @@ def test_required_fields_validation(tmp_path):
         yaml.dump(config_data, f)
 
     with pytest.raises(ValueError, match="Host must be specified"):
-        PostgresConfig.from_yaml(str(config_file), "test_db")
+        PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
     # Missing port
     config_data["connections"]["test_db"]["host"] = "localhost"
@@ -116,7 +116,7 @@ def test_required_fields_validation(tmp_path):
         yaml.dump(config_data, f)
 
     with pytest.raises(ValueError, match="Port must be specified"):
-        PostgresConfig.from_yaml(str(config_file), "test_db")
+        PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
     # Missing database name
     config_data["connections"]["test_db"]["port"] = 5432
@@ -126,4 +126,4 @@ def test_required_fields_validation(tmp_path):
         yaml.dump(config_data, f)
 
     with pytest.raises(ValueError, match="Database name must be specified"):
-        PostgresConfig.from_yaml(str(config_file), "test_db")
+        PostgreSQLConfig.from_yaml(str(config_file), "test_db")

--- a/tests/integration/test_prompts.py
+++ b/tests/integration/test_prompts.py
@@ -8,7 +8,7 @@ import anyio
 import mcp.types as types
 from mcp import ClientSession
 import mcp.server.stdio
-from mcp_dbutils.base import DatabaseServer
+from mcp_dbutils.base import ConnectionServer
 from mcp_dbutils.log import create_logger
 
 # 创建测试用的 logger
@@ -20,7 +20,7 @@ async def test_prompts_capability(sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         # Get initialization options and verify prompts capability
         init_options = server.server.create_initialization_options()
@@ -33,7 +33,7 @@ async def test_list_prompts(sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         # Create bidirectional streams with proper types
         # Client -> Server stream (server receives messages and exceptions)

--- a/tests/integration/test_sqlite_config.py
+++ b/tests/integration/test_sqlite_config.py
@@ -51,7 +51,7 @@ def test_from_jdbc_url():
 def test_from_yaml_with_jdbc_url(tmp_path):
     """Test SqliteConfig creation from YAML with JDBC URL"""
     config_data = {
-        "databases": {
+        "connections": {
             "test_db": {
                 "type": "sqlite",
                 "jdbc_url": "jdbc:sqlite:/path/to/test.db",
@@ -74,7 +74,7 @@ def test_required_fields_validation(tmp_path):
     """Test validation of required configuration fields"""
     # Missing type
     config_data = {
-        "databases": {
+        "connections": {
             "test_db": {
                 "jdbc_url": "jdbc:sqlite:/path/to/test.db"
             }
@@ -89,7 +89,7 @@ def test_required_fields_validation(tmp_path):
         SqliteConfig.from_yaml(str(config_file), "test_db")
 
     # Wrong type
-    config_data["databases"]["test_db"]["type"] = "postgres"
+    config_data["connections"]["test_db"]["type"] = "postgres"
     
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
@@ -98,7 +98,7 @@ def test_required_fields_validation(tmp_path):
         SqliteConfig.from_yaml(str(config_file), "test_db")
 
     # Standard config (non-JDBC) missing path
-    config_data["databases"]["test_db"] = {
+    config_data["connections"]["test_db"] = {
         "type": "sqlite"
     }
     

--- a/tests/integration/test_sqlite_config.py
+++ b/tests/integration/test_sqlite_config.py
@@ -30,7 +30,7 @@ def test_parse_jdbc_url():
         parse_jdbc_url("sqlite:/path/to/test.db")
 
     # Test missing path
-    with pytest.raises(ValueError, match="Database path must be specified"):
+    with pytest.raises(ValueError, match="SQLite file path must be specified"):
         parse_jdbc_url("jdbc:sqlite:")
 
 def test_from_jdbc_url():

--- a/tests/integration/test_sqlite_config.py
+++ b/tests/integration/test_sqlite_config.py
@@ -3,7 +3,7 @@ import pytest
 import tempfile
 import yaml
 from pathlib import Path
-from mcp_dbutils.sqlite.config import SqliteConfig, parse_jdbc_url
+from mcp_dbutils.sqlite.config import SQLiteConfig, parse_jdbc_url
 
 def test_parse_jdbc_url():
     """Test JDBC URL parsing"""
@@ -34,9 +34,9 @@ def test_parse_jdbc_url():
         parse_jdbc_url("jdbc:sqlite:")
 
 def test_from_jdbc_url():
-    """Test SqliteConfig creation from JDBC URL"""
+    """Test SQLiteConfig creation from JDBC URL"""
     url = "jdbc:sqlite:/path/to/test.db"
-    config = SqliteConfig.from_jdbc_url(url)
+    config = SQLiteConfig.from_jdbc_url(url)
     
     assert str(Path(config.path)) == str(Path("/path/to/test.db"))
     assert config.password is None
@@ -44,12 +44,12 @@ def test_from_jdbc_url():
     assert config.type == "sqlite"
 
     # Test with password
-    config = SqliteConfig.from_jdbc_url(url, password="test_pass")
+    config = SQLiteConfig.from_jdbc_url(url, password="test_pass")
     assert config.password == "test_pass"
     assert config.uri is True
 
 def test_from_yaml_with_jdbc_url(tmp_path):
-    """Test SqliteConfig creation from YAML with JDBC URL"""
+    """Test SQLiteConfig creation from YAML with JDBC URL"""
     config_data = {
         "connections": {
             "test_db": {
@@ -64,7 +64,7 @@ def test_from_yaml_with_jdbc_url(tmp_path):
     with open(config_file, "w") as f:
         yaml.dump(config_data, f)
 
-    config = SqliteConfig.from_yaml(str(config_file), "test_db")
+    config = SQLiteConfig.from_yaml(str(config_file), "test_db")
     assert str(Path(config.path)) == str(Path("/path/to/test.db"))
     assert config.password == "test_pass"
     assert config.uri is True
@@ -86,7 +86,7 @@ def test_required_fields_validation(tmp_path):
         yaml.dump(config_data, f)
 
     with pytest.raises(ValueError, match="missing required 'type' field"):
-        SqliteConfig.from_yaml(str(config_file), "test_db")
+        SQLiteConfig.from_yaml(str(config_file), "test_db")
 
     # Wrong type
     config_data["connections"]["test_db"]["type"] = "postgres"
@@ -95,7 +95,7 @@ def test_required_fields_validation(tmp_path):
         yaml.dump(config_data, f)
 
     with pytest.raises(ValueError, match="Configuration is not SQLite type"):
-        SqliteConfig.from_yaml(str(config_file), "test_db")
+        SQLiteConfig.from_yaml(str(config_file), "test_db")
 
     # Standard config (non-JDBC) missing path
     config_data["connections"]["test_db"] = {
@@ -106,4 +106,4 @@ def test_required_fields_validation(tmp_path):
         yaml.dump(config_data, f)
 
     with pytest.raises(ValueError, match="must include 'path' field"):
-        SqliteConfig.from_yaml(str(config_file), "test_db")
+        SQLiteConfig.from_yaml(str(config_file), "test_db")

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -6,7 +6,7 @@ import anyio
 import mcp.types as types
 from mcp import ClientSession
 from mcp.shared.exceptions import McpError
-from mcp_dbutils.base import DatabaseServer
+from mcp_dbutils.base import ConnectionServer
 from mcp_dbutils.log import create_logger
 
 # 创建测试用的 logger
@@ -18,7 +18,7 @@ async def test_list_tables_tool(postgres_db, sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         # Create bidirectional streams
         client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)
@@ -82,7 +82,7 @@ async def test_describe_table_tool(postgres_db, sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         # Create bidirectional streams
         client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)
@@ -147,7 +147,7 @@ async def test_get_ddl_tool(postgres_db, sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         # Create bidirectional streams
         client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)
@@ -210,7 +210,7 @@ async def test_list_indexes_tool(postgres_db, sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         # Create bidirectional streams
         client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -47,7 +47,7 @@ async def test_list_tables_tool(postgres_db, sqlite_db, mcp_config):
                 assert "dbutils-run-query" in tool_names
 
                 # Test list_tables tool with PostgreSQL
-                result = await client.call_tool("dbutils-list-tables", {"database": "test_pg"})
+                result = await client.call_tool("dbutils-list-tables", {"connection": "test_pg"})
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
                 # 检查数据库类型前缀
@@ -55,7 +55,7 @@ async def test_list_tables_tool(postgres_db, sqlite_db, mcp_config):
                 assert "users" in result.content[0].text
 
                 # Test list_tables tool with SQLite
-                result = await client.call_tool("dbutils-list-tables", {"database": "test_sqlite"})
+                result = await client.call_tool("dbutils-list-tables", {"connection": "test_sqlite"})
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
                 # 检查数据库类型前缀
@@ -110,7 +110,7 @@ async def test_describe_table_tool(postgres_db, sqlite_db, mcp_config):
                 assert "dbutils-describe-table" in tool_names
 
                 # Test PostgreSQL describe-table
-                pg_args = {"database": "test_pg", "table": "users"}
+                pg_args = {"connection": "test_pg", "table": "users"}
                 result = await client.call_tool("dbutils-describe-table", pg_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
@@ -119,7 +119,7 @@ async def test_describe_table_tool(postgres_db, sqlite_db, mcp_config):
                 assert "Columns:" in result.content[0].text
 
                 # Test SQLite describe-table
-                sqlite_args = {"database": "test_sqlite", "table": "products"}
+                sqlite_args = {"connection": "test_sqlite", "table": "products"}
                 result = await client.call_tool("dbutils-describe-table", sqlite_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
@@ -175,7 +175,7 @@ async def test_get_ddl_tool(postgres_db, sqlite_db, mcp_config):
                 assert "dbutils-get-ddl" in tool_names
 
                 # Test PostgreSQL get-ddl
-                pg_args = {"database": "test_pg", "table": "users"}
+                pg_args = {"connection": "test_pg", "table": "users"}
                 result = await client.call_tool("dbutils-get-ddl", pg_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
@@ -183,7 +183,7 @@ async def test_get_ddl_tool(postgres_db, sqlite_db, mcp_config):
                 assert "CREATE TABLE users" in result.content[0].text
 
                 # Test SQLite get-ddl
-                sqlite_args = {"database": "test_sqlite", "table": "products"}
+                sqlite_args = {"connection": "test_sqlite", "table": "products"}
                 result = await client.call_tool("dbutils-get-ddl", sqlite_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
@@ -238,14 +238,14 @@ async def test_list_indexes_tool(postgres_db, sqlite_db, mcp_config):
                 assert "dbutils-list-indexes" in tool_names
 
                 # Test PostgreSQL list-indexes
-                pg_args = {"database": "test_pg", "table": "users"}
+                pg_args = {"connection": "test_pg", "table": "users"}
                 result = await client.call_tool("dbutils-list-indexes", pg_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
                 assert "[postgres]" in result.content[0].text
 
                 # Test SQLite list-indexes
-                sqlite_args = {"database": "test_sqlite", "table": "products"}
+                sqlite_args = {"connection": "test_sqlite", "table": "products"}
                 result = await client.call_tool("dbutils-list-indexes", sqlite_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"

--- a/tests/integration/test_tools.py
+++ b/tests/integration/test_tools.py
@@ -14,7 +14,7 @@ logger = create_logger("test-tools", True)  # debug=True 以显示所有日志
 
 @pytest.mark.asyncio
 async def test_list_tables_tool(postgres_db, sqlite_db, mcp_config):
-    """Test the list_tables tool with both PostgreSQL and SQLite databases"""
+    """Test the list_tables tool with both PostgreSQL and SQLite connections"""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
@@ -78,7 +78,7 @@ async def test_list_tables_tool(postgres_db, sqlite_db, mcp_config):
 
 @pytest.mark.asyncio
 async def test_describe_table_tool(postgres_db, sqlite_db, mcp_config):
-    """Test the dbutils-describe-table tool with both PostgreSQL and SQLite databases"""
+    """Test the dbutils-describe-table tool with both PostgreSQL and SQLite connections"""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
@@ -143,7 +143,7 @@ async def test_describe_table_tool(postgres_db, sqlite_db, mcp_config):
 
 @pytest.mark.asyncio
 async def test_get_ddl_tool(postgres_db, sqlite_db, mcp_config):
-    """Test the dbutils-get-ddl tool with both PostgreSQL and SQLite databases"""
+    """Test the dbutils-get-ddl tool with both PostgreSQL and SQLite connections"""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
@@ -206,7 +206,7 @@ async def test_get_ddl_tool(postgres_db, sqlite_db, mcp_config):
 
 @pytest.mark.asyncio
 async def test_list_indexes_tool(postgres_db, sqlite_db, mcp_config):
-    """Test the dbutils-list-indexes tool with both PostgreSQL and SQLite databases"""
+    """Test the dbutils-list-indexes tool with both PostgreSQL and SQLite connections"""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()

--- a/tests/integration/test_tools_advanced.py
+++ b/tests/integration/test_tools_advanced.py
@@ -8,7 +8,7 @@ import anyio
 import mcp.types as types
 from mcp import ClientSession
 from mcp.shared.exceptions import McpError
-from mcp_dbutils.base import DatabaseServer
+from mcp_dbutils.base import ConnectionServer
 from mcp_dbutils.log import create_logger
 
 # 创建测试用的 logger
@@ -20,7 +20,7 @@ async def test_get_stats_tool(postgres_db, sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         # Create bidirectional streams
         client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)
@@ -82,7 +82,7 @@ async def test_list_constraints_tool(postgres_db, sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)
         server_to_client_send, server_to_client_recv = anyio.create_memory_object_stream[types.JSONRPCMessage](10)
@@ -139,7 +139,7 @@ async def test_explain_query_tool(postgres_db, sqlite_db, mcp_config):
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
-        server = DatabaseServer(config_path=tmp.name)
+        server = ConnectionServer(config_path=tmp.name)
 
         client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)
         server_to_client_send, server_to_client_recv = anyio.create_memory_object_stream[types.JSONRPCMessage](10)

--- a/tests/integration/test_tools_advanced.py
+++ b/tests/integration/test_tools_advanced.py
@@ -48,7 +48,7 @@ async def test_get_stats_tool(postgres_db, sqlite_db, mcp_config):
                 assert "dbutils-get-stats" in tool_names
 
                 # Test PostgreSQL stats
-                pg_args = {"database": "test_pg", "table": "users"}
+                pg_args = {"connection": "test_pg", "table": "users"}
                 result = await client.call_tool("dbutils-get-stats", pg_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
@@ -56,7 +56,7 @@ async def test_get_stats_tool(postgres_db, sqlite_db, mcp_config):
                 assert "Table Statistics for users" in result.content[0].text
 
                 # Test SQLite stats
-                sqlite_args = {"database": "test_sqlite", "table": "products"}
+                sqlite_args = {"connection": "test_sqlite", "table": "products"}
                 result = await client.call_tool("dbutils-get-stats", sqlite_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
@@ -106,7 +106,7 @@ async def test_list_constraints_tool(postgres_db, sqlite_db, mcp_config):
                 assert "dbutils-list-constraints" in tool_names
 
                 # Test PostgreSQL constraints
-                pg_args = {"database": "test_pg", "table": "users"}
+                pg_args = {"connection": "test_pg", "table": "users"}
                 result = await client.call_tool("dbutils-list-constraints", pg_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
@@ -114,7 +114,7 @@ async def test_list_constraints_tool(postgres_db, sqlite_db, mcp_config):
                 assert "Constraints for users" in result.content[0].text
 
                 # Test SQLite constraints
-                sqlite_args = {"database": "test_sqlite", "table": "products"}
+                sqlite_args = {"connection": "test_sqlite", "table": "products"}
                 result = await client.call_tool("dbutils-list-constraints", sqlite_args)
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
@@ -164,7 +164,7 @@ async def test_explain_query_tool(postgres_db, sqlite_db, mcp_config):
 
                 # Test PostgreSQL explain
                 pg_args = {
-                    "database": "test_pg",
+                    "connection": "test_pg",
                     "sql": "SELECT * FROM users WHERE id > 0"
                 }
                 result = await client.call_tool("dbutils-explain-query", pg_args)
@@ -175,7 +175,7 @@ async def test_explain_query_tool(postgres_db, sqlite_db, mcp_config):
 
                 # Test SQLite explain
                 sqlite_args = {
-                    "database": "test_sqlite",
+                    "connection": "test_sqlite",
                     "sql": "SELECT * FROM products WHERE id > 0"
                 }
                 result = await client.call_tool("dbutils-explain-query", sqlite_args)

--- a/tests/integration/test_tools_advanced.py
+++ b/tests/integration/test_tools_advanced.py
@@ -16,7 +16,7 @@ logger = create_logger("test-tools-advanced", True)  # debug=True 以显示所�
 
 @pytest.mark.asyncio
 async def test_get_stats_tool(postgres_db, sqlite_db, mcp_config):
-    """Test the dbutils-get-stats tool with both PostgreSQL and SQLite databases"""
+    """Test the dbutils-get-stats tool with both PostgreSQL and SQLite connections"""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
@@ -78,7 +78,7 @@ async def test_get_stats_tool(postgres_db, sqlite_db, mcp_config):
 
 @pytest.mark.asyncio
 async def test_list_constraints_tool(postgres_db, sqlite_db, mcp_config):
-    """Test the dbutils-list-constraints tool with both PostgreSQL and SQLite databases"""
+    """Test the dbutils-list-constraints tool with both PostgreSQL and SQLite connections"""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()
@@ -135,7 +135,7 @@ async def test_list_constraints_tool(postgres_db, sqlite_db, mcp_config):
 
 @pytest.mark.asyncio
 async def test_explain_query_tool(postgres_db, sqlite_db, mcp_config):
-    """Test the dbutils-explain-query tool with both PostgreSQL and SQLite databases"""
+    """Test the dbutils-explain-query tool with both PostgreSQL and SQLite connections"""
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(mcp_config, tmp)
         tmp.flush()


### PR DESCRIPTION
## Description
Rename 'databases' to 'connections' in configuration files and 'database' to 'connection' in API parameters for better clarity and consistency.

## Related Issue
Closes #19

## Implementation
1. Renamed the top-level configuration key from 'databases' to 'connections'
2. Renamed the MCP tool parameter from 'database' to 'connection'
3. Updated error messages and documentation to reflect these changes
4. Added backward compatibility for 'database' parameter in API calls

## Testing Steps
1. Update your configuration file to use 'connections' instead of 'databases'
2. Update your MCP tool calls to use 'connection' instead of 'database'
3. Verify that all functionality works as expected

## Breaking Changes
This is a breaking change that will require users to:
- Update their configuration files to use 'connections' instead of 'databases'
- Update their MCP tool calls to use 'connection' instead of 'database'

Since this is a breaking change, we should increment the major version number.