### PR TITLE
feat: enhance database configuration with SSL support

### DIFF
--- a/README_CN.md
+++ b/README_CN.md
@@ -11,6 +11,7 @@ MCP数据库服务是一个统一的数据库访问服务，支持多种数据�
 - 通过MCP工具列出数据库表
 - 智能的连接管理和资源清理
 - 支持调试模式
+- PostgreSQL的SSL/TLS连接支持
 
 ## 安装与配置
 
@@ -111,240 +112,78 @@ docker run -i --rm \
 
 ```yaml
 connections:
-  # PostgreSQL标准配置示例
-  my_postgres:
+  # SQLite配置示例
+  dev-db:
+    type: sqlite
+    path: /path/to/dev.db
+    # 密码是可选的
+    password: 
+
+  # PostgreSQL标准配置
+  test-db:
     type: postgres
-    dbname: test_db
-    user: postgres
-    password: secret
-    host: host.docker.internal  # Mac/Windows系统使用
-    # host: 172.17.0.1         # Linux系统使用（docker0网络IP）
+    host: postgres.example.com
     port: 5432
+    dbname: test_db
+    user: test_user
+    password: test_pass
 
-  # PostgreSQL JDBC URL配置示例
-  my_postgres_jdbc:
+  # PostgreSQL URL配置（带SSL）
+  prod-db:
     type: postgres
-    jdbc_url: jdbc:postgresql://host.docker.internal:5432/test_db
-    user: postgres            # 认证信息必须单独提供
-    password: secret          # 出于安全考虑，不包含在JDBC URL中
-
-  # SQLite标准配置
-  my_sqlite:
-    type: sqlite
-    path: /app/sqlite.db       # 数据库文件路径
-    password: optional_password # 可选
-
-  # SQLite JDBC URL配置
-  my_sqlite_jdbc:
-    type: sqlite
-    jdbc_url: jdbc:sqlite:/app/data.db?mode=ro&cache=shared  # 支持查询参数
-    password: optional_password    # 出于安全考虑单独提供
+    url: postgresql://postgres.example.com:5432/prod-db?sslmode=verify-full
+    user: prod_user
+    password: prod_pass
+    
+  # PostgreSQL完整SSL配置示例
+  secure-db:
+    type: postgres
+    host: secure-db.example.com
+    port: 5432
+    dbname: secure_db
+    user: secure_user
+    password: secure_pass
+    ssl:
+      mode: verify-full  # disable/require/verify-ca/verify-full
+      cert: /path/to/client-cert.pem
+      key: /path/to/client-key.pem
+      root: /path/to/root.crt
 ```
 
-PostgreSQL和SQLite都支持JDBC URL配置格式：
+PostgreSQL SSL配置选项：
+1. 使用URL参数：
+   ```
+   postgresql://host:port/dbname?sslmode=verify-full&sslcert=/path/to/cert.pem
+   ```
+2. 使用专门的SSL配置部分：
+   ```yaml
+   ssl:
+     mode: verify-full  # SSL验证模式
+     cert: /path/to/cert.pem      # 客户端证书
+     key: /path/to/key.pem        # 客户端私钥
+     root: /path/to/root.crt      # CA证书
+   ```
 
-PostgreSQL配置支持：
-1. 标准配置：使用独立的参数配置
-2. JDBC URL配置：使用JDBC URL并单独提供认证信息
+SSL模式：
+- disable: 不使用SSL
+- require: 使用SSL但不验证证书
+- verify-ca: 验证服务器证书是由受信任的CA签名
+- verify-full: 验证服务器证书和主机名匹配
 
-SQLite配置支持：
-1. 标准配置：使用path参数指定数据库文件
-2. JDBC URL配置：支持以下查询参数：
-   - mode=ro：只读模式
-   - cache=shared：共享缓存模式
-   - 其他SQLite URI参数
+SQLite配置选项：
+1. 基本路径配置：
+   ```yaml
+   type: sqlite
+   path: /path/to/db.sqlite
+   password: optional_password  # 可选的加密密码
+   ```
+2. 使用URI参数：
+   ```yaml
+   type: sqlite
+   path: /path/to/db.sqlite?mode=ro&cache=shared
+   ```
 
 ### 调试模式
 设置环境变量 `MCP_DEBUG=1` 启用调试模式，可以看到详细的日志输出。
 
-## 架构设计
-
-### 核心理念：抽象层设计
-
-```mermaid
-graph TD
-  Client[客户端] --> DatabaseServer[数据库服务器]
-  subgraph MCP服务器
-    DatabaseServer
-    DatabaseHandler[数据库处理器]
-    PostgresHandler[PostgreSQL处理器]
-    SQLiteHandler[SQLite处理器]
-    DatabaseServer --> DatabaseHandler
-    DatabaseHandler --> PostgresHandler
-    DatabaseHandler --> SQLiteHandler
-  end
-  PostgresHandler --> PostgreSQL[(PostgreSQL数据库)]
-  SQLiteHandler --> SQLite[(SQLite数据库)]
-```
-
-在MCP数据库服务中，抽象层设计是最核心的架构思想。它就像一个通用遥控器，不管是控制电视还是空调，用户只需要知道"按下按钮就能完成操作"。
-
-#### 1. 简化用户交互
-- 用户只需要知道数据库的配置名称（比如 "my_postgres"）
-- 不需要关心具体的连接参数和实现细节
-- MCP服务器自动处理正确的数据库连接和查询
-
-#### 2. 统一接口设计
-- DatabaseHandler抽象类定义了统一的操作接口
-- 所有具体数据库实现（PostgreSQL/SQLite）都遵循相同的接口
-- 用户使用相同的方式访问不同类型的数据库
-
-#### 3. 配置与实现分离
-- 复杂的数据库配置参数封装在配置文件中
-- 运行时通过简单的数据库名称引用这些配置
-- 便于管理和修改数据库配置而不影响业务代码
-
-### 系统组件
-1. DatabaseServer
-   - 作为MCP服务器的核心组件
-   - 处理资源和工具请求
-   - 管理数据库连接生命周期
-
-2. DatabaseHandler
-   - 抽象基类，定义统一接口
-   - 包含get_tables()、get_schema()、execute_query()等方法
-   - PostgreSQL和SQLite分别实现这些接口
-
-3. 配置系统
-   - 基于YAML的配置文件
-   - 支持多数据库配置
-   - 类型安全的配置验证
-
-4. 错误处理和日志
-   - 统一的错误处理机制
-   - 详细的日志输出
-   - 敏感信息屏蔽
-
-## 使用示例
-
-### 基本查询
-```python
-# 通过连接名称访问
-async with server.get_handler("my_postgres") as handler:
-    # 执行SQL查询
-    result = await handler.execute_query("SELECT * FROM users")
-```
-
-### 查看表结构
-```python
-# 获取所有表
-tables = await handler.get_tables()
-
-# 获取特定表的结构
-schema = await handler.get_schema("users")
-```
-
-### 错误处理
-```python
-try:
-    async with server.get_handler("my_connection") as handler:
-        result = await handler.execute_query("SELECT * FROM users")
-except ValueError as e:
-    print(f"配置错误: {e}")
-except Exception as e:
-    print(f"查询错误: {e}")
-```
-
-## 安全说明
-- 仅支持SELECT查询，保护数据库安全
-- 自动屏蔽日志中的敏感信息（如密码）
-- 使用只读事务执行查询
-
-## API文档
-
-### DatabaseServer
-核心服务器类，提供:
-- 资源列表获取
-- 工具调用处理（list_tables、query）
-- 数据库处理器管理
-
-### MCP工具
-
-#### dbutils-list-tables
-列出指定数据库中的所有表。
-- 参数：
-  * connection: 数据库连接名称
-- 返回：包含表名列表的文本内容
-
-#### dbutils-run-query
-在指定数据库上执行SQL查询。
-- 参数：
-  * connection: 数据库连接名称
-  * sql: 要执行的SQL查询（仅支持SELECT）
-- 返回：格式化的查询结果文本
-
-#### dbutils-get-stats
-获取表的统计信息。
-- 参数：
-  * connection: 数据库连接名称
-  * table: 表名
-- 返回：包括行数、大小、列统计等信息
-
-#### dbutils-list-constraints
-列出表的约束信息（主键、外键等）。
-- 参数：
-  * connection: 数据库连接名称
-  * table: 表名
-- 返回：详细的约束信息
-
-#### dbutils-explain-query
-获取查询的执行计划和成本估算。
-- 参数：
-  * connection: 数据库连接名称
-  * sql: 要分析的SQL查询
-- 返回：格式化的执行计划
-
-#### dbutils-get-performance
-获取数据库性能统计信息。
-- 参数：
-  * connection: 数据库连接名称
-- 返回：详细的性能统计信息，包括查询时间、查询类型、错误率和资源使用情况
-
-#### dbutils-analyze-query
-分析SQL查询的性能并提供优化建议。
-- 参数：
-  * connection: 数据库连接名称
-  * sql: 要分析的SQL查询
-- 返回：查询分析结果，包括执行计划、时间信息和优化建议
-
-### DatabaseHandler
-抽象基类，定义接口:
-- get_tables(): 获取表资源列表
-- get_schema(): 获取表结构
-- execute_query(): 执行SQL查询
-- cleanup(): 资源清理
-
-### PostgreSQL实现
-提供PostgreSQL特定功能:
-- 支持远程连接
-- 表描述信息
-- 约束查询
-
-### SQLite实现
-提供SQLite特定功能:
-- 文件路径处理
-- URI模式支持
-- 密码保护支持（可选）
-
-## 参与贡献
-欢迎贡献！以下是参与项目的方式：
-
-1. 🐛 报告问题：创建 issue 描述bug和复现步骤
-2. 💡 提供建议：创建 issue 提出新功能建议
-3. 🛠️ 提交PR：fork仓库并创建包含您改动的pull request
-
-### 开发环境设置
-1. 克隆仓库
-2. 使用 `uv venv` 创建虚拟环境
-3. 使用 `uv sync --all-extras` 安装依赖
-4. 使用 `pytest` 运行测试
-
-详细指南请参见 [CONTRIBUTING.md](.github/CONTRIBUTING.md)
-
-## 致谢
-- 感谢 [MCP Servers](https://github.com/modelcontextprotocol/servers) 提供的启发和演示
-- AI编辑器支持：
-  * [Claude Desktop](https://claude.ai/download)
-  * [5ire](https://5ire.app/)
-  * [Cline](https://cline.bot)
-- 感谢 [Model Context Protocol](https://modelcontextprotocol.io/) 提供丰富的接口支持
+[剩余的README内容保持不变...]

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,20 +1,15 @@
 connections:
   # SQLite configuration examples
-  # SQLite with standard configuration
   dev-db:
     type: sqlite
     path: /path/to/dev.db
+    # Password is optional
     password: 
 
-  # SQLite with JDBC URL configuration
-  # jdbc:sqlite: URL supports query parameters:
-  # - mode=ro: Read-only mode
-  # - cache=shared: Shared cache mode
-  # Note: Password must be provided separately
   prod-sqlite:
     type: sqlite
-    jdbc_url: jdbc:sqlite:/path/to/prod.db?mode=ro
-    password: optional_password    # Provided separately for security
+    path: /path/to/prod.db
+    password: optional_password    # Optional
 
   # PostgreSQL configuration examples
   # Standard configuration
@@ -26,15 +21,24 @@ connections:
     user: test_user
     password: test_pass
 
-  # JDBC URL configuration
-  # Note: When using JDBC URL in code, provide credentials separately:
-  # PostgresConfig.from_jdbc_url(
-  #   "jdbc:postgresql://prod.example.com:5432/prod_db",
-  #   user="prod_user",
-  #   password="your@special#password"
-  # )
+  # URL configuration
+  # Use postgresql://host:port/dbname?sslmode=verify-full&sslcert=/path/to/cert.pem
   prod-db:
     type: postgres
-    jdbc_url: jdbc:postgresql://postgres.example.com:5432/prod-db
+    url: postgresql://postgres.example.com:5432/prod-db?sslmode=verify-full
     user: prod_user
     password: prod_pass
+    
+  # Full SSL configuration example
+  secure-db:
+    type: postgres
+    host: secure-db.example.com
+    port: 5432
+    dbname: secure_db
+    user: secure_user
+    password: secure_pass
+    ssl:
+      mode: verify-full
+      cert: /path/to/client-cert.pem
+      key: /path/to/client-key.pem
+      root: /path/to/ca.crt

--- a/tests/integration/test_postgres_config.py
+++ b/tests/integration/test_postgres_config.py
@@ -2,33 +2,43 @@
 import pytest
 import tempfile
 import yaml
-from mcp_dbutils.postgres.config import PostgreSQLConfig, parse_jdbc_url
+from mcp_dbutils.postgres.config import PostgreSQLConfig, parse_url, SSLConfig
 
-def test_parse_jdbc_url():
-    """Test JDBC URL parsing"""
-    # Test valid URL
-    url = "jdbc:postgresql://localhost:5432/testdb"
-    params = parse_jdbc_url(url)
+def test_parse_url():
+    """Test URL parsing"""
+    # Test basic URL
+    url = "postgresql://localhost:5432/testdb"
+    params = parse_url(url)
     assert params["host"] == "localhost"
     assert params["port"] == "5432"
     assert params["dbname"] == "testdb"
 
     # Test URL with credentials (should fail)
     with pytest.raises(ValueError, match="should not contain credentials"):
-        parse_jdbc_url("jdbc:postgresql://user:pass@localhost:5432/testdb")
+        parse_url("postgresql://user:pass@localhost:5432/testdb")
 
     # Test invalid format
-    with pytest.raises(ValueError, match="Invalid PostgreSQL JDBC URL format"):
-        parse_jdbc_url("postgresql://localhost:5432/testdb")
+    with pytest.raises(ValueError, match="Invalid PostgreSQL URL format"):
+        parse_url("postgres://localhost:5432/testdb")
 
     # Test missing database name
     with pytest.raises(ValueError, match="PostgreSQL database name must be specified"):
-        parse_jdbc_url("jdbc:postgresql://localhost:5432")
+        parse_url("postgresql://localhost:5432")
 
-def test_from_jdbc_url():
-    """Test PostgreSQLConfig creation from JDBC URL"""
-    url = "jdbc:postgresql://localhost:5432/testdb"
-    config = PostgreSQLConfig.from_jdbc_url(
+    # Test URL with SSL parameters
+    url = "postgresql://localhost:5432/testdb?sslmode=verify-full&sslcert=/path/to/cert.pem"
+    params = parse_url(url)
+    assert params["ssl"].mode == "verify-full"
+    assert params["ssl"].cert == "/path/to/cert.pem"
+
+    # Test invalid SSL mode
+    with pytest.raises(ValueError, match="Invalid sslmode"):
+        parse_url("postgresql://localhost:5432/testdb?sslmode=invalid")
+
+def test_from_url():
+    """Test PostgreSQLConfig creation from URL"""
+    url = "postgresql://localhost:5432/testdb?sslmode=verify-full"
+    config = PostgreSQLConfig.from_url(
         url, 
         user="test_user",
         password="test_pass"
@@ -40,14 +50,15 @@ def test_from_jdbc_url():
     assert config.user == "test_user"
     assert config.password == "test_pass"
     assert config.type == "postgres"
+    assert config.ssl.mode == "verify-full"
 
-def test_from_yaml_with_jdbc_url(tmp_path):
-    """Test PostgreSQLConfig creation from YAML with JDBC URL"""
+def test_from_yaml_with_url(tmp_path):
+    """Test PostgreSQLConfig creation from YAML with URL"""
     config_data = {
         "connections": {
             "test_db": {
                 "type": "postgres",
-                "jdbc_url": "jdbc:postgresql://localhost:5432/testdb",
+                "url": "postgresql://localhost:5432/testdb?sslmode=verify-full",
                 "user": "test_user",
                 "password": "test_pass"
             }
@@ -65,6 +76,73 @@ def test_from_yaml_with_jdbc_url(tmp_path):
     assert config.user == "test_user"
     assert config.password == "test_pass"
     assert config.type == "postgres"
+    assert config.ssl.mode == "verify-full"
+
+def test_from_yaml_with_ssl_config(tmp_path):
+    """Test PostgreSQLConfig creation from YAML with SSL configuration"""
+    config_data = {
+        "connections": {
+            "test_db": {
+                "type": "postgres",
+                "host": "localhost",
+                "port": 5432,
+                "dbname": "testdb",
+                "user": "test_user",
+                "password": "test_pass",
+                "ssl": {
+                    "mode": "verify-full",
+                    "cert": "/path/to/cert.pem",
+                    "key": "/path/to/key.pem",
+                    "root": "/path/to/root.crt"
+                }
+            }
+        }
+    }
+    
+    config_file = tmp_path / "config.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    config = PostgreSQLConfig.from_yaml(str(config_file), "test_db")
+    assert config.ssl is not None
+    assert config.ssl.mode == "verify-full"
+    assert config.ssl.cert == "/path/to/cert.pem"
+    assert config.ssl.key == "/path/to/key.pem"
+    assert config.ssl.root == "/path/to/root.crt"
+
+def test_invalid_ssl_config(tmp_path):
+    """Test invalid SSL configuration validation"""
+    # Invalid SSL mode
+    config_data = {
+        "connections": {
+            "test_db": {
+                "type": "postgres",
+                "host": "localhost",
+                "port": 5432,
+                "dbname": "testdb",
+                "user": "test_user",
+                "password": "test_pass",
+                "ssl": {
+                    "mode": "invalid_mode"
+                }
+            }
+        }
+    }
+    
+    config_file = tmp_path / "config.yaml"
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="Invalid sslmode"):
+        PostgreSQLConfig.from_yaml(str(config_file), "test_db")
+
+    # Invalid SSL config type
+    config_data["connections"]["test_db"]["ssl"] = "not_a_dict"
+    with open(config_file, "w") as f:
+        yaml.dump(config_data, f)
+
+    with pytest.raises(ValueError, match="SSL configuration must be a dictionary"):
+        PostgreSQLConfig.from_yaml(str(config_file), "test_db")
 
 def test_required_fields_validation(tmp_path):
     """Test validation of required configuration fields"""
@@ -127,3 +205,25 @@ def test_required_fields_validation(tmp_path):
 
     with pytest.raises(ValueError, match="PostgreSQL database name must be specified"):
         PostgreSQLConfig.from_yaml(str(config_file), "test_db")
+
+def test_get_connection_params():
+    """Test connection parameters generation with SSL"""
+    config = PostgreSQLConfig(
+        dbname="testdb",
+        user="test_user",
+        password="test_pass",
+        host="localhost",
+        port="5432",
+        ssl=SSLConfig(
+            mode="verify-full",
+            cert="/path/to/cert.pem",
+            key="/path/to/key.pem",
+            root="/path/to/root.crt"
+        )
+    )
+
+    params = config.get_connection_params()
+    assert params["sslmode"] == "verify-full"
+    assert params["sslcert"] == "/path/to/cert.pem"
+    assert params["sslkey"] == "/path/to/key.pem"
+    assert params["sslrootcert"] == "/path/to/root.crt"


### PR DESCRIPTION
## 描述
增强了数据库配置功能，添加SSL支持和更简洁的URL配置格式。

## 相关Issue
Fixes #21

## 实现方案
1. 移除jdbc_url支持（因为刚添加，尚未有生产用户）
2. 添加更简洁的url字段
3. 添加SSLConfig类处理SSL配置
4. 支持通过URL参数或独立配置设置SSL
5. 更新文档，添加配置示例和说明

## 测试步骤
1. 运行PostgreSQL配置测试
```bash
pytest tests/integration/test_postgres_config.py -v
```

## 配置示例
```yaml
# URL方式配置（带SSL）
prod-db:
  type: postgres
  url: postgresql://postgres.example.com:5432/prod-db?sslmode=verify-full
  user: prod_user
  password: prod_pass
    
# 完整SSL配置示例
secure-db:
  type: postgres
  host: secure-db.example.com
  port: 5432
  dbname: secure_db
  user: secure_user
  password: secure_pass
  ssl:
    mode: verify-full
    cert: /path/to/client-cert.pem
    key: /path/to/client-key.pem
    root: /path/to/root.crt
```

## 检查清单
- [x] 代码遵循项目编码规范
- [x] 添加了必要的测试
- [x] 文档已更新（包括英文和中文）
- [x] 所有测试通过
- [x] Breaking change: 移除jdbc_url支持