### PR TITLE
refactor: unify log name and update configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ uvx mcp-dbutils --config /path/to/config.yaml
 Add to Claude configuration:
 ```json
 "mcpServers": {
-  "mcp-dbutils": {
+  "dbutils": {
     "command": "uvx",
     "args": [
       "mcp-dbutils",
@@ -64,7 +64,7 @@ pip install mcp-dbutils
 Add to Claude configuration:
 ```json
 "mcpServers": {
-  "mcp-dbutils": {
+  "dbutils": {
     "command": "python",
     "args": [
       "-m",
@@ -91,7 +91,7 @@ docker run -i --rm \
 Add to Claude configuration:
 ```json
 "mcpServers": {
-  "mcp-dbutils": {
+  "dbutils": {
     "command": "docker",
     "args": [
       "run",

--- a/README_CN.md
+++ b/README_CN.md
@@ -26,7 +26,7 @@ uvx mcp-dbutils --config /path/to/config.yaml
 添加到 Claude 配置：
 ```json
 "mcpServers": {
-  "mcp-dbutils": {
+  "dbutils": {
     "command": "uvx",
     "args": [
       "mcp-dbutils",
@@ -48,7 +48,7 @@ pip install mcp-dbutils
 添加到 Claude 配置：
 ```json
 "mcpServers": {
-  "mcp-dbutils": {
+  "dbutils": {
     "command": "python",
     "args": [
       "-m",
@@ -75,7 +75,7 @@ docker run -i --rm \
 添加到 Claude 配置：
 ```json
 "mcpServers": {
-  "mcp-dbutils": {
+  "dbutils": {
     "command": "docker",
     "args": [
       "run",

--- a/src/mcp_dbutils/__init__.py
+++ b/src/mcp_dbutils/__init__.py
@@ -9,13 +9,13 @@ import yaml
 from importlib.metadata import metadata
 
 from .log import create_logger
-from .base import ConnectionServer
+from .base import ConnectionServer, LOG_NAME
 
 # 获取包信息
 pkg_meta = metadata("mcp-dbutils")
 
 # 创建全局logger
-log = create_logger(pkg_meta["Name"])
+log = create_logger(LOG_NAME)
 
 async def run_server():
     """服务器运行逻辑"""
@@ -30,7 +30,7 @@ async def run_server():
 
     # 更新logger的debug状态
     global log
-    log = create_logger(pkg_meta["Name"], debug)
+    log = create_logger(LOG_NAME, debug)
 
     log("info", f"MCP Connection Utilities Service v{pkg_meta['Version']}")
     if debug:

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -31,6 +31,9 @@ from .stats import ResourceStats
 # 获取包信息用于日志命名
 pkg_meta = metadata("mcp-dbutils")
 
+# 日志名称常量
+LOG_NAME = "dbutils"
+
 # MCP日志级别常量
 LOG_LEVEL_DEBUG = "debug"       # 0
 LOG_LEVEL_INFO = "info"        # 1
@@ -56,7 +59,7 @@ class ConnectionHandler(ABC):
         self.connection = connection
         self.debug = debug
         # 创建stderr日志记录器用于本地调试
-        self.log = create_logger(f"{pkg_meta['Name']}.handler.{connection}", debug)
+        self.log = create_logger(f"{LOG_NAME}.handler.{connection}", debug)
         self.stats = ResourceStats()
         self._session = None
 
@@ -246,9 +249,9 @@ class ConnectionServer:
         self.debug = debug
         # 获取包信息用于服务器配置
         pkg_meta = metadata("mcp-dbutils")
-        self.logger = create_logger(f"{pkg_meta['Name']}.server", debug)
+        self.logger = create_logger(f"{LOG_NAME}.server", debug)
         self.server = Server(
-            name=pkg_meta["Name"],
+            name=LOG_NAME,
             version=pkg_meta["Version"]
         )
         self._session = None

--- a/src/mcp_dbutils/mysql/server.py
+++ b/src/mcp_dbutils/mysql/server.py
@@ -9,7 +9,7 @@ from ..log import create_logger
 from .config import MySQLConfig
 
 # 获取包信息用于日志命名
-pkg_meta = metadata("mcp-dbutils")
+from ..base import LOG_NAME
 
 class MySQLServer(ConnectionServer):
     def __init__(self, config: MySQLConfig, config_path: Optional[str] = None):
@@ -21,7 +21,7 @@ class MySQLServer(ConnectionServer):
         super().__init__(config_path, config.debug)
         self.config = config
         self.config_path = config_path
-        self.log = create_logger(f"{pkg_meta['Name']}.db.mysql", config.debug)
+        self.log = create_logger(f"{LOG_NAME}.db.mysql", config.debug)
         # 创建连接池
         try:
             conn_params = config.get_connection_params()

--- a/src/mcp_dbutils/postgres/server.py
+++ b/src/mcp_dbutils/postgres/server.py
@@ -9,7 +9,8 @@ from ..log import create_logger
 from .config import PostgreSQLConfig
 
 # 获取包信息用于日志命名
-pkg_meta = metadata("mcp-dbutils")
+from ..base import LOG_NAME
+
 class PostgreSQLServer(ConnectionServer):
     def __init__(self, config: PostgreSQLConfig, config_path: Optional[str] = None):
         """初始化PostgreSQL服务器
@@ -20,7 +21,7 @@ class PostgreSQLServer(ConnectionServer):
         super().__init__(config_path, config.debug)
         self.config = config
         self.config_path = config_path
-        self.log = create_logger(f"{pkg_meta['Name']}.db.postgres", config.debug)
+        self.log = create_logger(f"{LOG_NAME}.db.postgres", config.debug)
         # 创建连接池
         try:
             conn_params = config.get_connection_params()

--- a/src/mcp_dbutils/sqlite/server.py
+++ b/src/mcp_dbutils/sqlite/server.py
@@ -12,7 +12,7 @@ from ..log import create_logger
 from .config import SQLiteConfig
 
 # 获取包信息用于日志命名
-pkg_meta = metadata("mcp-dbutils")
+from ..base import LOG_NAME
 
 class SQLiteServer(ConnectionServer):
     def __init__(self, config: SQLiteConfig, config_path: Optional[str] = None):
@@ -24,7 +24,7 @@ class SQLiteServer(ConnectionServer):
         super().__init__(config_path, config.debug)
         self.config = config
         self.config_path = config_path
-        self.log = create_logger(f"{pkg_meta['Name']}.db.sqlite", config.debug)
+        self.log = create_logger(f"{LOG_NAME}.db.sqlite", config.debug)
 
         # 确保数据库目录存在
         db_file = Path(self.config.absolute_path)


### PR DESCRIPTION
- Add LOG_NAME constant in base.py to unify log name as 'dbutils'
- Update all create_logger calls to use LOG_NAME
- Update Server name to use LOG_NAME
- Update configuration examples in README to use 'dbutils' as server name
- Keep package name and GitHub repository name unchanged

This change ensures consistent naming in logs and documentation while maintaining compatibility.