### PR TITLE
修复SonarCloud问题提取逻辑，仅获取PR相关问题

### DIFF
--- a/.github/workflows/quality-assurance.yml
+++ b/.github/workflows/quality-assurance.yml
@@ -283,9 +283,18 @@ jobs:
             const projectKey = process.env.SONAR_PROJECT_KEY;
             console.log(`获取项目 ${projectKey} 的SonarCloud问题...`);
             
+            // 获取PR号
+            let prNumberParam = '';
+            if (context.issue.number) {
+              prNumberParam = `&pullRequest=${context.issue.number}`;
+              console.log(`处理PR #${context.issue.number}的SonarCloud问题`);
+            } else {
+              console.log('未检测到PR号，将获取所有未解决的问题');
+            }
+            
             // 获取未解决的问题
             const issuesResponse = await fetch(
-              `https://sonarcloud.io/api/issues/search?componentKeys=${projectKey}&resolved=false&ps=500`,
+              `https://sonarcloud.io/api/issues/search?componentKeys=${projectKey}${prNumberParam}&resolved=false&ps=500`,
               { headers: { Authorization: `Bearer ${process.env.SONAR_TOKEN}` } }
             ).then(res => res.json());
             

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ filterwarnings = [
 # Ruff配置
 [tool.ruff]
 # 目标Python版本
-target-version = "0.15.2"
+target-version = "py310"
 # 行长度限制
 line-length = 88
 # 排除的文件和目录


### PR DESCRIPTION
## 描述

修复SonarCloud问题提取逻辑，使其仅获取PR相关问题，而不是所有未解决的问题：

- 添加了PR号的检测和日志记录
- 在API调用中添加了pullRequest参数
- 保留了在没有PR号的情况下获取所有问题的能力

## 相关Issue

Fixes #42

## 实现方案

修改了.github/workflows/quality-assurance.yml中的SonarCloud问题提取API调用，添加了PR上下文判断，并根据情况添加pullRequest参数。

## 测试步骤

- 创建PR，测试SonarCloud分析是否正确生成只包含PR中问题的报告

## 检查清单

- [x] 代码遵循项目编码规范
- [x] 所有测试通过