### PR TITLE
重构：移除生产代码中的测试依赖

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ filterwarnings = [
 # Ruff配置
 [tool.ruff]
 # 目标Python版本
-target-version = "0.15.3"
+target-version = "py310"
 # 行长度限制
 line-length = 88
 # 排除的文件和目录

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -1,17 +1,5 @@
 """Connection server base class"""
 
-class ConnectionHandlerError(Exception):
-    """Base exception for connection errors"""
-    pass
-
-class ConfigurationError(ConnectionHandlerError):
-    """Configuration related errors"""
-    pass
-
-class ConnectionError(ConnectionHandlerError):
-    """Connection related errors"""
-    pass
-
 import json
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
@@ -26,6 +14,18 @@ from mcp.server import Server
 
 from .log import create_logger
 from .stats import ResourceStats
+
+class ConnectionHandlerError(Exception):
+    """Base exception for connection errors"""
+    pass
+
+class ConfigurationError(ConnectionHandlerError):
+    """Configuration related errors"""
+    pass
+
+class ConnectionError(ConnectionHandlerError):
+    """Connection related errors"""
+    pass
 
 # 常量定义
 DATABASE_CONNECTION_NAME = "Database connection name"

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -17,8 +17,7 @@ from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from datetime import datetime
 from importlib.metadata import metadata
-from typing import AsyncContextManager
-from unittest.mock import MagicMock
+from typing import AsyncContextManager, Any, Dict
 
 import mcp.server.stdio
 import mcp.types as types
@@ -347,14 +346,16 @@ class ConnectionServer:
 
                 handler.stats.record_connection_start()
                 self.send_log(LOG_LEVEL_DEBUG, f"Handler created successfully for {connection}")
-                # 处理MagicMock对象，避免JSON序列化错误
+                # 使用通用的方式处理统计信息序列化
                 try:
-                    stats_dict = handler.stats.to_dict()
-                    stats_json = json.dumps(stats_dict)
-                    self.send_log(LOG_LEVEL_INFO, f"Resource stats: {stats_json}")
+                    if hasattr(handler.stats, 'to_dict') and callable(handler.stats.to_dict):
+                        stats_dict = handler.stats.to_dict()
+                        stats_json = json.dumps(stats_dict)
+                        self.send_log(LOG_LEVEL_INFO, f"Resource stats: {stats_json}")
+                    else:
+                        self.send_log(LOG_LEVEL_INFO, "Resource stats not available")
                 except TypeError:
-                    # 在测试环境中，stats可能是MagicMock对象
-                    self.send_log(LOG_LEVEL_INFO, "Resource stats: [Mock object in test environment]")
+                    self.send_log(LOG_LEVEL_INFO, "Resource stats: [Could not serialize stats object]")
                 yield handler
             except yaml.YAMLError as e:
                 raise ConfigurationError(f"Invalid YAML configuration: {str(e)}")
@@ -364,16 +365,19 @@ class ConnectionServer:
                 if handler:
                     self.send_log(LOG_LEVEL_DEBUG, f"Cleaning up handler for {connection}")
                     handler.stats.record_connection_end()
-                    # 处理MagicMock对象，避免JSON序列化错误
+                    # 使用通用的方式处理统计信息序列化
                     try:
-                        stats_dict = handler.stats.to_dict()
-                        stats_json = json.dumps(stats_dict)
-                        self.send_log(LOG_LEVEL_INFO, f"Final resource stats: {stats_json}")
+                        if hasattr(handler.stats, 'to_dict') and callable(handler.stats.to_dict):
+                            stats_dict = handler.stats.to_dict()
+                            stats_json = json.dumps(stats_dict)
+                            self.send_log(LOG_LEVEL_INFO, f"Final resource stats: {stats_json}")
+                        else:
+                            self.send_log(LOG_LEVEL_INFO, "Final resource stats not available")
                     except TypeError:
-                        # 在测试环境中，stats可能是MagicMock对象
-                        self.send_log(LOG_LEVEL_INFO, "Final resource stats: [Mock object in test environment]")
-                    # 在测试环境中，handler可能是MagicMock对象，但cleanup可能是AsyncMock
-                    await handler.cleanup()
+                        self.send_log(LOG_LEVEL_INFO, "Final resource stats: [Could not serialize stats object]")
+                    # 清理资源
+                    if hasattr(handler, 'cleanup') and callable(handler.cleanup):
+                        await handler.cleanup()
 
     def _setup_handlers(self):
         """Setup MCP handlers"""

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
 from datetime import datetime
 from importlib.metadata import metadata
-from typing import AsyncContextManager, Any, Dict
+from typing import Any, AsyncContextManager, Dict
 
 import mcp.server.stdio
 import mcp.types as types
@@ -14,6 +14,7 @@ from mcp.server import Server
 
 from .log import create_logger
 from .stats import ResourceStats
+
 
 class ConnectionHandlerError(Exception):
     """Base exception for connection errors"""

--- a/src/mcp_dbutils/sqlite/server.py
+++ b/src/mcp_dbutils/sqlite/server.py
@@ -163,7 +163,7 @@ class SQLiteServer(ConnectionServer):
                 columns = [desc[0] for desc in cursor.description]
                 formatted_results = [dict(zip(columns, row)) for row in results]
 
-                # 在测试环境中，connection可能是MagicMock对象，不能序列化为JSON
+                # 使用更通用的方法确定配置名称
                 config_name = connection if isinstance(connection, str) else 'default'
                 result_text = json.dumps({
                     'type': 'sqlite',
@@ -179,7 +179,7 @@ class SQLiteServer(ConnectionServer):
                 return [types.TextContent(type="text", text=result_text)]
 
         except sqlite3.Error as e:
-            # 在测试环境中，connection可能是MagicMock对象，不能序列化为JSON
+            # 使用更通用的方法确定配置名称
             config_name = connection if isinstance(connection, str) else 'default'
             error_msg = json.dumps({
                 'type': 'sqlite',


### PR DESCRIPTION
## 描述

重构了生产代码，移除了为测试而添加的特殊处理逻辑，改用更通用的类型检查方法。主要修改：

1. 从src/mcp_dbutils/base.py中移除unittest.mock导入
2. 将MagicMock特定处理改为通用的类型检查
3. 改进错误消息和注释以更好地反映代码的实际目的

所有单元测试和集成测试均已通过，证明修改没有破坏现有功能。

## 已完成任务

- [x] 重构base.py中的MagicMock处理逻辑
- [x] 重构sqlite/server.py中的MagicMock处理逻辑
- [x] 验证所有测试通过

解决 #44