### PR TITLE
Fix: Release workflow no longer modifies ruff target-version

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -6,7 +6,7 @@
     "@semantic-release/changelog",
     ["@semantic-release/exec", {
       "verifyConditionsCmd": "uv --version",
-      "prepareCmd": "sed -i.bak 's/version = \".*\"/version = \"${nextRelease.version}\"/g' pyproject.toml && rm -f pyproject.toml.bak",
+      "prepareCmd": "sed -i.bak '0,/version = \".*\"/s//version = \"${nextRelease.version}\"/' pyproject.toml && rm -f pyproject.toml.bak",
       "publishCmd": "uv build"
     }],
     ["@semantic-release/git", {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ filterwarnings = [
 # Ruff配置
 [tool.ruff]
 # 目标Python版本
-target-version = "0.15.4"
+target-version = "py310"
 # 行长度限制
 line-length = 88
 # 排除的文件和目录


### PR DESCRIPTION
Resolves #48.\n\nThis PR fixes the sed command in the release workflow to only replace the first occurrence of 'version = ".*"' in pyproject.toml, ensuring that only the package version is updated while leaving the ruff target-version configuration intact.\n\nChanges made:\n1. Modified the sed command in .releaserc.json to only target the first match\n2. Restored the correct ruff target-version to 'py310' instead of the incorrect '0.15.4'\n\nThis fix will prevent future releases from breaking the ruff configuration.