### PR TITLE
文档更新：Cursor配置方式更新

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ MCP 数据库工具采用**安全优先的架构**设计，非常适合注重数
 - 找到并编辑您客户端的MCP配置文件：
   - **Claude Desktop (Mac)**: `~/Library/Application Support/Claude/claude_desktop_config.json`
   - **Cline (Mac)**: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+  - **Cursor (Mac)**: `~/.cursor/mcp.json`
   - **其他客户端**：请参阅您客户端的文档以了解MCP配置文件位置
 - 在JSON文件中添加以下配置：
 
@@ -140,18 +141,10 @@ MCP 数据库工具采用**安全优先的架构**设计，非常适合注重数
 }
 ```
 
-**对于Cursor：**
-- 打开Cursor
-- 前往设置 → MCP
-- 点击"添加MCP服务器"并填写：
-  - 名称：`Database Utility MCP`
-  - 类型：`Command`（默认）
-  - 命令：`uvx mcp-dbutils --config /完整/路径/到您的/config.yaml`
-
 > **uvx设置的重要注意事项：**
 > - 将`/完整/路径/到您的/config.yaml`替换为您配置文件的实际完整路径
-> - 如果收到找不到uvx的错误，请确保步骤1成功完成
-> - 您可以在终端中输入`uvx --version`来验证uvx是否已安装
+> - 如果您收到uvx未找到的错误，请确保已成功完成步骤1
+> - 您可以通过在终端中输入`uv --version`来验证uvx是否已安装
 
 #### 方式B：使用Docker手动安装
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -124,6 +124,7 @@ This method uses `uvx`, which is part of the Python package manager tool called 
 - Locate and edit your client's MCP configuration file:
   - **Claude Desktop (Mac)**: `~/Library/Application Support/Claude/claude_desktop_config.json`
   - **Cline (Mac)**: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+  - **Cursor (Mac)**: `~/.cursor/mcp.json`
   - **Other clients**: Refer to your client's documentation for the MCP configuration file location
 - Add the following configuration to the JSON file:
 
@@ -138,18 +139,10 @@ This method uses `uvx`, which is part of the Python package manager tool called 
 }
 ```
 
-**For Cursor:**
-- Open Cursor
-- Go to Settings → MCP
-- Click "Add MCP Server" and fill in:
-  - Name: `Database Utility MCP`
-  - Type: `Command` (default)
-  - Command: `uvx mcp-dbutils --config /full/path/to/your/config.yaml`
-
 > **Important Notes for uvx Setup:**
 > - Replace `/full/path/to/your/config.yaml` with the actual full path to your config file
 > - If you get an error about uvx not being found, make sure step 1 was completed successfully
-> - You can verify uvx is installed by typing `uvx --version` in your terminal
+> - You can verify uvx is installed by typing `uv --version` in your terminal
 
 #### Option B: Manual Installation with Docker
 
@@ -163,6 +156,7 @@ This method uses `uvx`, which is part of the Python package manager tool called 
 - Locate and edit your client's MCP configuration file:
   - **Claude Desktop (Mac)**: `~/Library/Application Support/Claude/claude_desktop_config.json`
   - **Cline (Mac)**: `~/Library/Application Support/Code/User/globalStorage/saoudrizwan.claude-dev/settings/cline_mcp_settings.json`
+  - **Cursor (Mac/Windows)**: `~/.cursor/mcp.json`
   - **Other clients**: Refer to your client's documentation for the MCP configuration file location
 - Add the following configuration to the JSON file:
 


### PR DESCRIPTION
解决Issue #62

Cursor做了更新，配置MCP服务器的方式发生了变化。本PR更新了README中的相关内容：

- 添加Cursor使用~/.cursor/mcp.json的配置路径
- 删除了Cursor的专有配置部分，整合到JSON配置方式中
- 保持中英文文档的一致性
- 修复了README_EN.md中的JSON格式问题

这些更改使得文档更加准确并反映了Cursor最新的配置方式。

Resolves #62