### PR TITLE
Add dbutils-list-connections tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ MCP Database Utilities 是一个多功能的 MCP 服务，它使您的 AI 能够
 
 MCP 数据库工具提供了多种工具，使 AI 能够与您的数据库交互：
 
+- **dbutils-list-connections**：列出配置中的所有可用数据库连接
 - **dbutils-list-tables**：列出数据库中的所有表
 - **dbutils-run-query**：执行 SQL 查询（仅 SELECT）
 - **dbutils-get-stats**：获取表统计信息

--- a/README_EN.md
+++ b/README_EN.md
@@ -73,6 +73,7 @@ We offer multiple installation methods, including uvx, Docker, and Smithery. For
 
 MCP Database Utilities provides several tools that your AI can use:
 
+- **dbutils-list-connections**: Lists all available database connections in your configuration
 - **dbutils-list-tables**: Lists all tables in a database
 - **dbutils-run-query**: Executes a SQL query (SELECT only)
 - **dbutils-get-stats**: Gets statistics about a table

--- a/docs/en/usage.md
+++ b/docs/en/usage.md
@@ -15,6 +15,32 @@ The basic workflow for using MCP Database Utilities is as follows:
 
 MCP Database Utilities provides several tools that your AI can use:
 
+### dbutils-list-connections
+
+Lists all available database connections defined in your configuration.
+
+**Example Interaction**:
+
+**You**: "What database connections do I have available?"
+
+**AI**: "I'll check your available database connections. Here's what I found:
+
+1. **postgres-db**
+   - Type: PostgreSQL
+   - Host: localhost
+   - Database: analytics
+   - User: analyst
+
+2. **sqlite-db**
+   - Type: SQLite
+   - Path: /path/to/database.db
+
+3. **mysql-db**
+   - Type: MySQL
+   - Host: db.example.com
+   - Database: customer_data
+   - User: reader"
+
 ### dbutils-list-tables
 
 Lists all tables in the specified database.

--- a/docs/zh/usage.md
+++ b/docs/zh/usage.md
@@ -15,6 +15,32 @@ MCP 数据库工具的基本操作流程如下：
 
 MCP 数据库工具提供了几个您的 AI 可以使用的工具：
 
+### dbutils-list-connections
+
+列出配置中定义的所有可用数据库连接。
+
+**示例交互**：
+
+**您**："我有哪些可用的数据库连接？"
+
+**AI**："我来为您查看可用的数据库连接。以下是我找到的连接：
+
+1. **postgres-db**
+   - 类型：PostgreSQL
+   - 主机：localhost
+   - 数据库：analytics
+   - 用户：analyst
+
+2. **sqlite-db**
+   - 类型：SQLite
+   - 路径：/path/to/database.db
+
+3. **mysql-db**
+   - 类型：MySQL
+   - 主机：db.example.com
+   - 数据库：customer_data
+   - 用户：reader"
+
 ### dbutils-list-tables
 
 列出指定数据库中的所有表。

--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -18,15 +18,21 @@ from .stats import ResourceStats
 
 class ConnectionHandlerError(Exception):
     """Base exception for connection errors"""
+
     pass
+
 
 class ConfigurationError(ConnectionHandlerError):
     """Configuration related errors"""
+
     pass
+
 
 class ConnectionError(ConnectionHandlerError):
     """Connection related errors"""
+
     pass
+
 
 # 常量定义
 DATABASE_CONNECTION_NAME = "Database connection name"
@@ -44,14 +50,15 @@ pkg_meta = metadata("mcp-dbutils")
 LOG_NAME = "dbutils"
 
 # MCP日志级别常量
-LOG_LEVEL_DEBUG = "debug"       # 0
-LOG_LEVEL_INFO = "info"        # 1
-LOG_LEVEL_NOTICE = "notice"    # 2
+LOG_LEVEL_DEBUG = "debug"  # 0
+LOG_LEVEL_INFO = "info"  # 1
+LOG_LEVEL_NOTICE = "notice"  # 2
 LOG_LEVEL_WARNING = "warning"  # 3
-LOG_LEVEL_ERROR = "error"      # 4
-LOG_LEVEL_CRITICAL = "critical" # 5
-LOG_LEVEL_ALERT = "alert"      # 6
-LOG_LEVEL_EMERGENCY = "emergency" # 7
+LOG_LEVEL_ERROR = "error"  # 4
+LOG_LEVEL_CRITICAL = "critical"  # 5
+LOG_LEVEL_ALERT = "alert"  # 6
+LOG_LEVEL_EMERGENCY = "emergency"  # 7
+
 
 class ConnectionHandler(ABC):
     """Abstract base class defining common interface for connection handlers"""
@@ -83,10 +90,9 @@ class ConnectionHandler(ABC):
         self.log(level, message)
 
         # MCP日志通知
-        if self._session and hasattr(self._session, 'request_context'):
+        if self._session and hasattr(self._session, "request_context"):
             self._session.request_context.session.send_log_message(
-                level=level,
-                data=message
+                level=level, data=message
             )
 
     @property
@@ -119,12 +125,18 @@ class ConnectionHandler(ABC):
             duration = (datetime.now() - start_time).total_seconds()
             self.stats.record_query_duration(sql, duration)
             self.stats.update_memory_usage(result)
-            self.send_log(LOG_LEVEL_INFO, f"Query executed in {duration*1000:.2f}ms. Resource stats: {json.dumps(self.stats.to_dict())}")
+            self.send_log(
+                LOG_LEVEL_INFO,
+                f"Query executed in {duration * 1000:.2f}ms. Resource stats: {json.dumps(self.stats.to_dict())}",
+            )
             return result
         except Exception as e:
             duration = (datetime.now() - start_time).total_seconds()
             self.stats.record_error(e.__class__.__name__)
-            self.send_log(LOG_LEVEL_ERROR, f"Query error after {duration*1000:.2f}ms - {str(e)}\nResource stats: {json.dumps(self.stats.to_dict())}")
+            self.send_log(
+                LOG_LEVEL_ERROR,
+                f"Query error after {duration * 1000:.2f}ms - {str(e)}\nResource stats: {json.dumps(self.stats.to_dict())}",
+            )
             raise
 
     @abstractmethod
@@ -213,7 +225,9 @@ class ConnectionHandler(ABC):
         """Cleanup resources"""
         pass
 
-    async def execute_tool_query(self, tool_name: str, table_name: str = "", sql: str = "") -> str:
+    async def execute_tool_query(
+        self, tool_name: str, table_name: str = "", sql: str = ""
+    ) -> str:
         """Execute a tool query and return formatted result
 
         Args:
@@ -245,13 +259,19 @@ class ConnectionHandler(ABC):
                 raise ValueError(f"Unknown tool: {tool_name}")
 
             self.stats.update_memory_usage(result)
-            self.send_log(LOG_LEVEL_INFO, f"Resource stats: {json.dumps(self.stats.to_dict())}")
+            self.send_log(
+                LOG_LEVEL_INFO, f"Resource stats: {json.dumps(self.stats.to_dict())}"
+            )
             return f"[{self.db_type}]\n{result}"
 
         except Exception as e:
             self.stats.record_error(e.__class__.__name__)
-            self.send_log(LOG_LEVEL_ERROR, f"Tool error - {str(e)}\nResource stats: {json.dumps(self.stats.to_dict())}")
+            self.send_log(
+                LOG_LEVEL_ERROR,
+                f"Tool error - {str(e)}\nResource stats: {json.dumps(self.stats.to_dict())}",
+            )
             raise
+
 
 class ConnectionServer:
     """Unified connection server class"""
@@ -268,10 +288,7 @@ class ConnectionServer:
         # 获取包信息用于服务器配置
         pkg_meta = metadata("mcp-dbutils")
         self.logger = create_logger(f"{LOG_NAME}.server", debug)
-        self.server = Server(
-            name=LOG_NAME,
-            version=pkg_meta["Version"]
-        )
+        self.server = Server(name=LOG_NAME, version=pkg_meta["Version"])
         self._session = None
         self._setup_handlers()
         self._setup_prompts()
@@ -287,17 +304,15 @@ class ConnectionServer:
         self.logger(level, message)
 
         # MCP日志通知
-        if hasattr(self.server, 'session') and self.server.session:
+        if hasattr(self.server, "session") and self.server.session:
             try:
-                self.server.session.send_log_message(
-                    level=level,
-                    data=message
-                )
+                self.server.session.send_log_message(level=level, data=message)
             except Exception as e:
                 self.logger("error", f"Failed to send MCP log message: {str(e)}")
 
     def _setup_prompts(self):
         """Setup prompts handlers"""
+
         @self.server.list_prompts()
         async def handle_list_prompts() -> list[types.Prompt]:
             """Handle prompts/list request"""
@@ -320,22 +335,30 @@ class ConnectionServer:
         Raises:
             ConfigurationError: 如果配置文件格式不正确或连接不存在
         """
-        with open(self.config_path, 'r') as f:
+        with open(self.config_path, "r") as f:
             config = yaml.safe_load(f)
-            if not config or 'connections' not in config:
-                raise ConfigurationError("Configuration file must contain 'connections' section")
-            if connection not in config['connections']:
-                available_connections = list(config['connections'].keys())
-                raise ConfigurationError(f"Connection not found: {connection}. Available connections: {available_connections}")
+            if not config or "connections" not in config:
+                raise ConfigurationError(
+                    "Configuration file must contain 'connections' section"
+                )
+            if connection not in config["connections"]:
+                available_connections = list(config["connections"].keys())
+                raise ConfigurationError(
+                    f"Connection not found: {connection}. Available connections: {available_connections}"
+                )
 
-            db_config = config['connections'][connection]
+            db_config = config["connections"][connection]
 
-            if 'type' not in db_config:
-                raise ConfigurationError("Database configuration must include 'type' field")
+            if "type" not in db_config:
+                raise ConfigurationError(
+                    "Database configuration must include 'type' field"
+                )
 
             return db_config
 
-    def _create_handler_for_type(self, db_type: str, connection: str) -> ConnectionHandler:
+    def _create_handler_for_type(
+        self, db_type: str, connection: str
+    ) -> ConnectionHandler:
         """基于数据库类型创建相应的处理器
 
         Args:
@@ -351,23 +374,30 @@ class ConnectionServer:
         self.send_log(LOG_LEVEL_DEBUG, f"Creating handler for database type: {db_type}")
 
         try:
-            if db_type == 'sqlite':
+            if db_type == "sqlite":
                 from .sqlite.handler import SQLiteHandler
+
                 return SQLiteHandler(self.config_path, connection, self.debug)
-            elif db_type == 'postgres':
+            elif db_type == "postgres":
                 from .postgres.handler import PostgreSQLHandler
+
                 return PostgreSQLHandler(self.config_path, connection, self.debug)
-            elif db_type == 'mysql':
+            elif db_type == "mysql":
                 from .mysql.handler import MySQLHandler
+
                 return MySQLHandler(self.config_path, connection, self.debug)
             else:
                 raise ConfigurationError(f"Unsupported database type: {db_type}")
         except ImportError as e:
             # 捕获导入错误并转换为ConfigurationError，以保持与现有测试兼容
-            raise ConfigurationError(f"Failed to import handler for {db_type}: {str(e)}")
+            raise ConfigurationError(
+                f"Failed to import handler for {db_type}: {str(e)}"
+            )
 
     @asynccontextmanager
-    async def get_handler(self, connection: str) -> AsyncContextManager[ConnectionHandler]:
+    async def get_handler(
+        self, connection: str
+    ) -> AsyncContextManager[ConnectionHandler]:
         """Get connection handler
 
         Get appropriate connection handler based on connection name
@@ -384,15 +414,17 @@ class ConnectionServer:
         # Create appropriate handler based on database type
         handler = None
         try:
-            db_type = db_config['type']
+            db_type = db_config["type"]
             handler = self._create_handler_for_type(db_type, connection)
 
             # Set session for MCP logging
-            if hasattr(self.server, 'session'):
+            if hasattr(self.server, "session"):
                 handler._session = self.server.session
 
             handler.stats.record_connection_start()
-            self.send_log(LOG_LEVEL_DEBUG, f"Handler created successfully for {connection}")
+            self.send_log(
+                LOG_LEVEL_DEBUG, f"Handler created successfully for {connection}"
+            )
 
             yield handler
         finally:
@@ -400,7 +432,7 @@ class ConnectionServer:
                 self.send_log(LOG_LEVEL_DEBUG, f"Cleaning up handler for {connection}")
                 handler.stats.record_connection_end()
 
-                if hasattr(handler, 'cleanup') and callable(handler.cleanup):
+                if hasattr(handler, "cleanup") and callable(handler.cleanup):
                     await handler.cleanup()
 
     def _get_available_tools(self) -> list[types.Tool]:
@@ -419,11 +451,11 @@ class ConnectionServer:
                         "check_status": {
                             "type": "boolean",
                             "description": "Whether to check connection status (may be slow with many connections)",
-                            "default": False
+                            "default": False,
                         }
                     },
-                    "required": []
-                }
+                    "required": [],
+                },
             ),
             types.Tool(
                 name="dbutils-run-query",
@@ -433,15 +465,15 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         },
                         "sql": {
                             "type": "string",
-                            "description": "SQL query (SELECT only)"
-                        }
+                            "description": "SQL query (SELECT only)",
+                        },
                     },
-                    "required": ["connection", "sql"]
-                }
+                    "required": ["connection", "sql"],
+                },
             ),
             types.Tool(
                 name="dbutils-list-tables",
@@ -451,11 +483,11 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         }
                     },
-                    "required": ["connection"]
-                }
+                    "required": ["connection"],
+                },
             ),
             types.Tool(
                 name="dbutils-describe-table",
@@ -465,15 +497,15 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         },
                         "table": {
                             "type": "string",
-                            "description": "Table name to describe"
-                        }
+                            "description": "Table name to describe",
+                        },
                     },
-                    "required": ["connection", "table"]
-                }
+                    "required": ["connection", "table"],
+                },
             ),
             types.Tool(
                 name="dbutils-get-ddl",
@@ -483,15 +515,15 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         },
                         "table": {
                             "type": "string",
-                            "description": "Table name to get DDL for"
-                        }
+                            "description": "Table name to get DDL for",
+                        },
                     },
-                    "required": ["connection", "table"]
-                }
+                    "required": ["connection", "table"],
+                },
             ),
             types.Tool(
                 name="dbutils-list-indexes",
@@ -501,15 +533,15 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         },
                         "table": {
                             "type": "string",
-                            "description": "Table name to list indexes for"
-                        }
+                            "description": "Table name to list indexes for",
+                        },
                     },
-                    "required": ["connection", "table"]
-                }
+                    "required": ["connection", "table"],
+                },
             ),
             types.Tool(
                 name="dbutils-get-stats",
@@ -519,15 +551,15 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         },
                         "table": {
                             "type": "string",
-                            "description": "Table name to get statistics for"
-                        }
+                            "description": "Table name to get statistics for",
+                        },
                     },
-                    "required": ["connection", "table"]
-                }
+                    "required": ["connection", "table"],
+                },
             ),
             types.Tool(
                 name="dbutils-list-constraints",
@@ -537,15 +569,15 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         },
                         "table": {
                             "type": "string",
-                            "description": "Table name to list constraints for"
-                        }
+                            "description": "Table name to list constraints for",
+                        },
                     },
-                    "required": ["connection", "table"]
-                }
+                    "required": ["connection", "table"],
+                },
             ),
             types.Tool(
                 name="dbutils-explain-query",
@@ -555,15 +587,15 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         },
                         "sql": {
                             "type": "string",
-                            "description": "SQL query to explain"
-                        }
+                            "description": "SQL query to explain",
+                        },
                     },
-                    "required": ["connection", "sql"]
-                }
+                    "required": ["connection", "sql"],
+                },
             ),
             types.Tool(
                 name="dbutils-get-performance",
@@ -573,11 +605,11 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         }
                     },
-                    "required": ["connection"]
-                }
+                    "required": ["connection"],
+                },
             ),
             types.Tool(
                 name="dbutils-analyze-query",
@@ -587,19 +619,21 @@ class ConnectionServer:
                     "properties": {
                         "connection": {
                             "type": "string",
-                            "description": DATABASE_CONNECTION_NAME
+                            "description": DATABASE_CONNECTION_NAME,
                         },
                         "sql": {
                             "type": "string",
-                            "description": "SQL query to analyze"
-                        }
+                            "description": "SQL query to analyze",
+                        },
                     },
-                    "required": ["connection", "sql"]
-                }
-            )
+                    "required": ["connection", "sql"],
+                },
+            ),
         ]
 
-    async def _handle_list_connections(self, check_status: bool = False) -> list[types.TextContent]:
+    async def _handle_list_connections(
+        self, check_status: bool = False
+    ) -> list[types.TextContent]:
         """处理列出数据库连接工具调用
 
         Args:
@@ -612,13 +646,18 @@ class ConnectionServer:
 
         try:
             # 读取配置文件
-            with open(self.config_path, 'r') as f:
+            with open(self.config_path, "r") as f:
                 config = yaml.safe_load(f)
-                if not config or 'connections' not in config:
-                    return [types.TextContent(type="text", text="No database connections found in configuration.")]
+                if not config or "connections" not in config:
+                    return [
+                        types.TextContent(
+                            type="text",
+                            text="No database connections found in configuration.",
+                        )
+                    ]
 
                 # 获取配置中的所有连接
-                for conn_name, conn_config in config['connections'].items():
+                for conn_name, conn_config in config["connections"].items():
                     db_type = conn_config.get("type", "unknown")
                     connection_info = []
 
@@ -631,14 +670,18 @@ class ConnectionServer:
                         if "path" in conn_config:
                             connection_info.append(f"Path: {conn_config['path']}")
                         elif "database" in conn_config:
-                            connection_info.append(f"Database: {conn_config['database']}")
+                            connection_info.append(
+                                f"Database: {conn_config['database']}"
+                            )
                     elif db_type in ["mysql", "postgres", "postgresql"]:
                         if "host" in conn_config:
                             connection_info.append(f"Host: {conn_config['host']}")
                         if "port" in conn_config:
                             connection_info.append(f"Port: {conn_config['port']}")
                         if "database" in conn_config:
-                            connection_info.append(f"Database: {conn_config['database']}")
+                            connection_info.append(
+                                f"Database: {conn_config['database']}"
+                            )
                         if "user" in conn_config:
                             connection_info.append(f"User: {conn_config['user']}")
                         # 不显示密码
@@ -656,10 +699,18 @@ class ConnectionServer:
                     connections.append("\n".join(connection_info))
         except Exception as e:
             self.send_log(LOG_LEVEL_ERROR, f"Error listing connections: {str(e)}")
-            return [types.TextContent(type="text", text=f"Error listing connections: {str(e)}")]
+            return [
+                types.TextContent(
+                    type="text", text=f"Error listing connections: {str(e)}"
+                )
+            ]
 
         if not connections:
-            return [types.TextContent(type="text", text="No database connections found in configuration.")]
+            return [
+                types.TextContent(
+                    type="text", text="No database connections found in configuration."
+                )
+            ]
 
         result = "Available database connections:\n\n" + "\n\n".join(connections)
         return [types.TextContent(type="text", text=result)]
@@ -677,19 +728,35 @@ class ConnectionServer:
             tables = await handler.get_tables()
             if not tables:
                 # 空表列表的情况也返回数据库类型
-                return [types.TextContent(type="text", text=f"[{handler.db_type}] No tables found")]
+                return [
+                    types.TextContent(
+                        type="text", text=f"[{handler.db_type}] No tables found"
+                    )
+                ]
 
-            formatted_tables = "\n".join([
-                f"Table: {table.name}\n" +
-                f"URI: {table.uri}\n" +
-                (f"Description: {table.description}\n" if table.description else "") +
-                "---"
-                for table in tables
-            ])
+            formatted_tables = "\n".join(
+                [
+                    f"Table: {table.name}\n"
+                    + f"URI: {table.uri}\n"
+                    + (
+                        f"Description: {table.description}\n"
+                        if table.description
+                        else ""
+                    )
+                    + "---"
+                    for table in tables
+                ]
+            )
             # 添加数据库类型前缀
-            return [types.TextContent(type="text", text=f"[{handler.db_type}]\n{formatted_tables}")]
+            return [
+                types.TextContent(
+                    type="text", text=f"[{handler.db_type}]\n{formatted_tables}"
+                )
+            ]
 
-    async def _handle_run_query(self, connection: str, sql: str) -> list[types.TextContent]:
+    async def _handle_run_query(
+        self, connection: str, sql: str
+    ) -> list[types.TextContent]:
         """处理运行查询工具调用
 
         Args:
@@ -713,7 +780,9 @@ class ConnectionServer:
             result = await handler.execute_query(sql)
             return [types.TextContent(type="text", text=result)]
 
-    async def _handle_table_tools(self, name: str, connection: str, table: str) -> list[types.TextContent]:
+    async def _handle_table_tools(
+        self, name: str, connection: str, table: str
+    ) -> list[types.TextContent]:
         """处理表相关工具调用
 
         Args:
@@ -734,7 +803,9 @@ class ConnectionServer:
             result = await handler.execute_tool_query(name, table_name=table)
             return [types.TextContent(type="text", text=result)]
 
-    async def _handle_explain_query(self, connection: str, sql: str) -> list[types.TextContent]:
+    async def _handle_explain_query(
+        self, connection: str, sql: str
+    ) -> list[types.TextContent]:
         """处理解释查询工具调用
 
         Args:
@@ -765,9 +836,15 @@ class ConnectionServer:
         """
         async with self.get_handler(connection) as handler:
             performance_stats = handler.stats.get_performance_stats()
-            return [types.TextContent(type="text", text=f"[{handler.db_type}]\n{performance_stats}")]
+            return [
+                types.TextContent(
+                    type="text", text=f"[{handler.db_type}]\n{performance_stats}"
+                )
+            ]
 
-    async def _handle_analyze_query(self, connection: str, sql: str) -> list[types.TextContent]:
+    async def _handle_analyze_query(
+        self, connection: str, sql: str
+    ) -> list[types.TextContent]:
         """处理查询分析工具调用
 
         Args:
@@ -794,7 +871,10 @@ class ConnectionServer:
                     await handler.execute_query(sql)
                 except Exception as e:
                     # If query fails, we still provide the execution plan
-                    self.send_log(LOG_LEVEL_ERROR, f"Query execution failed during analysis: {str(e)}")
+                    self.send_log(
+                        LOG_LEVEL_ERROR,
+                        f"Query execution failed during analysis: {str(e)}",
+                    )
             duration = (datetime.now() - start_time).total_seconds()
 
             # Combine analysis results
@@ -802,10 +882,10 @@ class ConnectionServer:
                 f"[{handler.db_type}] Query Analysis",
                 f"SQL: {sql}",
                 "",
-                f"Execution Time: {duration*1000:.2f}ms",
+                f"Execution Time: {duration * 1000:.2f}ms",
                 "",
                 "Execution Plan:",
-                explain_result
+                explain_result,
             ]
 
             # Add optimization suggestions
@@ -816,7 +896,9 @@ class ConnectionServer:
 
             return [types.TextContent(type="text", text="\n".join(analysis))]
 
-    def _get_optimization_suggestions(self, explain_result: str, duration: float) -> list[str]:
+    def _get_optimization_suggestions(
+        self, explain_result: str, duration: float
+    ) -> list[str]:
         """根据执行计划和耗时获取优化建议
 
         Args:
@@ -834,32 +916,37 @@ class ConnectionServer:
         if duration > 0.5:  # 500ms
             suggestions.append("- Query is slow, consider optimizing or adding caching")
         if "temporary" in explain_result.lower():
-            suggestions.append("- Query creates temporary tables, consider restructuring")
+            suggestions.append(
+                "- Query creates temporary tables, consider restructuring"
+            )
 
         return suggestions
 
     def _setup_handlers(self):
         """Setup MCP handlers"""
+
         @self.server.list_resources()
-        async def handle_list_resources(arguments: dict | None = None) -> list[types.Resource]:
-            if not arguments or 'connection' not in arguments:
+        async def handle_list_resources(
+            arguments: dict | None = None,
+        ) -> list[types.Resource]:
+            if not arguments or "connection" not in arguments:
                 # Return empty list when no connection specified
                 return []
 
-            connection = arguments['connection']
+            connection = arguments["connection"]
             async with self.get_handler(connection) as handler:
                 return await handler.get_tables()
 
         @self.server.read_resource()
         async def handle_read_resource(uri: str, arguments: dict | None = None) -> str:
-            if not arguments or 'connection' not in arguments:
+            if not arguments or "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
 
-            parts = uri.split('/')
+            parts = uri.split("/")
             if len(parts) < 3:
                 raise ConfigurationError(INVALID_URI_FORMAT_ERROR)
 
-            connection = arguments['connection']
+            connection = arguments["connection"]
             table_name = parts[-2]  # URI format: xxx/table_name/schema
 
             async with self.get_handler(connection) as handler:
@@ -870,7 +957,9 @@ class ConnectionServer:
             return self._get_available_tools()
 
         @self.server.call_tool()
-        async def handle_call_tool(name: str, arguments: dict) -> list[types.TextContent]:
+        async def handle_call_tool(
+            name: str, arguments: dict
+        ) -> list[types.TextContent]:
             # Special case for list-connections which doesn't require a connection
             if name == "dbutils-list-connections":
                 check_status = arguments.get("check_status", False)
@@ -886,8 +975,13 @@ class ConnectionServer:
             elif name == "dbutils-run-query":
                 sql = arguments.get("sql", "").strip()
                 return await self._handle_run_query(connection, sql)
-            elif name in ["dbutils-describe-table", "dbutils-get-ddl", "dbutils-list-indexes",
-                         "dbutils-get-stats", "dbutils-list-constraints"]:
+            elif name in [
+                "dbutils-describe-table",
+                "dbutils-get-ddl",
+                "dbutils-list-indexes",
+                "dbutils-get-stats",
+                "dbutils-list-constraints",
+            ]:
                 table = arguments.get("table", "").strip()
                 return await self._handle_table_tools(name, connection, table)
             elif name == "dbutils-explain-query":
@@ -905,7 +999,5 @@ class ConnectionServer:
         """Run server"""
         async with mcp.server.stdio.stdio_server() as streams:
             await self.server.run(
-                streams[0],
-                streams[1],
-                self.server.create_initialization_options()
+                streams[0], streams[1], self.server.create_initialization_options()
             )

--- a/src/mcp_dbutils/sqlite/handler.py
+++ b/src/mcp_dbutils/sqlite/handler.py
@@ -98,7 +98,7 @@ class SQLiteHandler(ConnectionHandler):
                 end_time = time.time()
                 elapsed_ms = (end_time - start_time) * 1000
                 self.log("debug", f"Query executed in {elapsed_ms:.2f}ms")
-                
+
                 if is_select:
                     # Get column names
                     columns = [description[0] for description in cur.description]
@@ -110,7 +110,7 @@ class SQLiteHandler(ConnectionHandler):
                         for i, col_name in enumerate(columns):
                             row_dict[col_name] = row[i]
                         results.append(row_dict)
-                    
+
                     return str({
                         "columns": columns,
                         "rows": results
@@ -136,13 +136,13 @@ class SQLiteHandler(ConnectionHandler):
                 # 获取表信息
                 cur.execute(f"PRAGMA table_info({table_name})")
                 columns = cur.fetchall()
-                
+
                 # SQLite不支持表级注释，但我们可以获取表的详细信息
                 description = [
                     f"Table: {table_name}\n",
                     COLUMNS_HEADER
                 ]
-                
+
                 for col in columns:
                     col_info = [
                         f"  {col[1]} ({col[2]})",
@@ -152,9 +152,9 @@ class SQLiteHandler(ConnectionHandler):
                     ]
                     description.extend(col_info)
                     description.append("")  # Empty line between columns
-                
+
                 return "\n".join(description)
-                
+
         except sqlite3.Error as e:
             error_msg = f"Failed to get table description: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
@@ -168,25 +168,25 @@ class SQLiteHandler(ConnectionHandler):
                 # SQLite provides the complete CREATE statement
                 cur.execute("SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table_name,))
                 result = cur.fetchone()
-                
+
                 if not result:
                     return f"Table {table_name} not found"
-                
+
                 ddl = result[0]
-                
+
                 # Get indexes
                 cur.execute("SELECT sql FROM sqlite_master WHERE type='index' AND tbl_name=?", (table_name,))
                 indexes = cur.fetchall()
-                
+
                 # Add index definitions
                 if indexes:
                     ddl = ddl + "\n\n-- Indexes:"
                     for idx in indexes:
                         if idx[0]:  # Some internal indexes might have NULL sql
                             ddl = ddl + "\n" + idx[0] + ";"
-                            
+
                 return ddl
-                
+
         except sqlite3.Error as e:
             error_msg = f"Failed to get table DDL: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
@@ -197,49 +197,49 @@ class SQLiteHandler(ConnectionHandler):
         try:
             with sqlite3.connect(self.config.path) as conn:
                 cur = conn.cursor()
-                
+
                 # Check if table exists
                 cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table_name,))
                 if not cur.fetchone():
                     raise ConnectionHandlerError(f"Table '{table_name}' doesn't exist")
-                
+
                 # 获取索引列表
                 cur.execute(f"PRAGMA index_list({table_name})")
                 indexes = cur.fetchall()
-                
+
                 if not indexes:
                     return f"No indexes found on table {table_name}"
-                
+
                 formatted_indexes = [f"Indexes for {table_name}:"]
-                
+
                 for idx in indexes:
                     # 获取索引详细信息
                     cur.execute(f"PRAGMA index_info({idx[1]})")
                     index_info = cur.fetchall()
-                    
+
                     # 获取索引的SQL定义
                     cur.execute("SELECT sql FROM sqlite_master WHERE type='index' AND name=?", (idx[1],))
                     sql = cur.fetchone()
-                    
+
                     index_details = [
                         f"\nIndex: {idx[1]}",
                         f"Type: {'UNIQUE' if idx[2] else 'INDEX'}",
                         COLUMNS_HEADER
                     ]
-                    
+
                     for col in index_info:
                         index_details.append(f"  - {col[2]}")
-                        
+
                     if sql and sql[0]:
                         index_details.extend([
                             "Definition:",
                             f"  {sql[0]}"
                         ])
-                        
+
                     formatted_indexes.extend(index_details)
-                
+
                 return "\n".join(formatted_indexes)
-                
+
         except sqlite3.Error as e:
             error_msg = f"Failed to get index information: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
@@ -250,33 +250,33 @@ class SQLiteHandler(ConnectionHandler):
         try:
             with sqlite3.connect(self.config.path) as conn:
                 cur = conn.cursor()
-                
+
                 # Check if table exists
                 cur.execute("SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table_name,))
                 if not cur.fetchone():
                     raise ConnectionHandlerError(f"Table '{table_name}' doesn't exist")
-                
+
                 # Get basic table information
                 cur.execute(f"PRAGMA table_info({table_name})")
                 columns = cur.fetchall()
-                
+
                 # Count rows
                 cur.execute(f"SELECT COUNT(*) FROM {table_name}")
                 row_count = cur.fetchone()[0]
-                
+
                 # Get index information
                 cur.execute(f"PRAGMA index_list({table_name})")
                 indexes = cur.fetchall()
-                
+
                 # Get page count and size
                 cur.execute("PRAGMA page_count")
                 page_count = cur.fetchone()[0]
                 cur.execute("PRAGMA page_size")
                 page_size = cur.fetchone()[0]
-                
+
                 # Calculate total size
                 total_size = page_count * page_size
-                
+
                 # Format size in human readable format
                 def format_size(size):
                     for unit in ['B', 'KB', 'MB', 'GB']:
@@ -284,7 +284,7 @@ class SQLiteHandler(ConnectionHandler):
                             return f"{size:.2f} {unit}"
                         size /= 1024
                     return f"{size:.2f} TB"
-                
+
                 # Get column statistics
                 column_stats = []
                 for col in columns:
@@ -295,7 +295,7 @@ class SQLiteHandler(ConnectionHandler):
                     # Get distinct value count
                     cur.execute(f"SELECT COUNT(DISTINCT {col_name}) FROM {table_name}")
                     distinct_count = cur.fetchone()[0]
-                    
+
                     column_stats.append({
                         'name': col_name,
                         'type': col[2],
@@ -303,7 +303,7 @@ class SQLiteHandler(ConnectionHandler):
                         'null_percent': (null_count / row_count * 100) if row_count > 0 else 0,
                         'distinct_count': distinct_count
                     })
-                
+
                 # Format output
                 output = [
                     f"Table Statistics for {table_name}:",
@@ -314,7 +314,7 @@ class SQLiteHandler(ConnectionHandler):
                     f"  Index Count: {len(indexes)}\n",
                     "Column Statistics:"
                 ]
-                
+
                 for stat in column_stats:
                     col_info = [
                         f"  {stat['name']} ({stat['type']}):",
@@ -323,7 +323,7 @@ class SQLiteHandler(ConnectionHandler):
                     ]
                     output.extend(col_info)
                     output.append("")  # Empty line between columns
-                
+
                 return "\n".join(output)
 
         except sqlite3.Error as e:
@@ -336,21 +336,21 @@ class SQLiteHandler(ConnectionHandler):
         try:
             with sqlite3.connect(self.config.path) as conn:
                 cur = conn.cursor()
-                
+
                 # Get table info (includes PRIMARY KEY)
                 cur.execute(f"PRAGMA table_info({table_name})")
                 columns = cur.fetchall()
-                
+
                 # Get foreign keys
                 cur.execute(f"PRAGMA foreign_key_list({table_name})")
                 foreign_keys = cur.fetchall()
-                
+
                 # Get indexes (for UNIQUE constraints)
                 cur.execute(f"PRAGMA index_list({table_name})")
                 indexes = cur.fetchall()
-                
+
                 output = [f"Constraints for {table_name}:"]
-                
+
                 # Primary Key constraints
                 pk_columns = [col[1] for col in columns if col[5]]  # col[5] is pk flag
                 if pk_columns:
@@ -358,13 +358,13 @@ class SQLiteHandler(ConnectionHandler):
                         "\nPrimary Key Constraints:",
                         f"  PRIMARY KEY ({', '.join(pk_columns)})"
                     ])
-                
+
                 # Foreign Key constraints
                 if foreign_keys:
                     output.append("\nForeign Key Constraints:")
                     current_fk = None
                     fk_columns = []
-                    
+
                     for fk in foreign_keys:
                         # SQLite foreign_key_list format:
                         # id, seq, table, from, to, on_update, on_delete, match
@@ -380,10 +380,10 @@ class SQLiteHandler(ConnectionHandler):
                             output.append(f"    ON UPDATE: {fk[5]}")
                         if fk[6]:  # on_delete
                             output.append(f"    ON DELETE: {fk[6]}")
-                    
+
                     if fk_columns:
                         output.append(f"    ({', '.join(fk_columns)})")
-                
+
                 # Unique constraints (from indexes)
                 unique_indexes = [idx for idx in indexes if idx[2]]  # idx[2] is unique flag
                 if unique_indexes:
@@ -394,7 +394,7 @@ class SQLiteHandler(ConnectionHandler):
                         index_info = cur.fetchall()
                         columns = [info[2] for info in index_info]  # info[2] is column name
                         output.append(f"  UNIQUE ({', '.join(columns)})")
-                
+
                 # Check constraints
                 # Note: SQLite doesn't provide direct access to CHECK constraints through PRAGMA
                 # We need to parse the table creation SQL
@@ -403,7 +403,7 @@ class SQLiteHandler(ConnectionHandler):
                 if "CHECK" in create_sql.upper():
                     output.append("\nCheck Constraints:")
                     output.append("  See table DDL for CHECK constraints")
-                
+
                 return "\n".join(output)
 
         except sqlite3.Error as e:
@@ -416,18 +416,18 @@ class SQLiteHandler(ConnectionHandler):
         try:
             with sqlite3.connect(self.config.path) as conn:
                 cur = conn.cursor()
-                
+
                 # Check if the query is valid by preparing it
                 try:
                     # Use prepare to validate the query without executing it
                     conn.execute(f"EXPLAIN {sql}")
                 except sqlite3.Error as e:
                     raise ConnectionHandlerError(f"Failed to explain query: {str(e)}")
-                
+
                 # Get EXPLAIN output
                 cur.execute(f"EXPLAIN QUERY PLAN {sql}")
                 plan = cur.fetchall()
-                
+
                 # Format the output
                 output = [
                     "Query Execution Plan:",
@@ -435,26 +435,41 @@ class SQLiteHandler(ConnectionHandler):
                     "Details:",
                     "--------"
                 ]
-                
+
                 for step in plan:
                     # EXPLAIN QUERY PLAN format:
                     # id | parent | notused | detail
                     indent = "  " * (step[0] - step[1] if step[1] >= 0 else step[0])
                     output.append(f"{indent}{step[3]}")
-                
+
                 # Add query statistics
                 output.extend([
                     "\nNote: SQLite's EXPLAIN QUERY PLAN provides a high-level overview.",
                     "For detailed execution statistics, consider using EXPLAIN (not QUERY PLAN)",
                     "which shows the virtual machine instructions."
                 ])
-                
+
                 return "\n".join(output)
 
         except sqlite3.Error as e:
             error_msg = f"Failed to explain query: {str(e)}"
             self.stats.record_error(e.__class__.__name__)
             raise ConnectionHandlerError(error_msg)
+
+    async def test_connection(self) -> bool:
+        """Test database connection
+
+        Returns:
+            bool: True if connection is successful, False otherwise
+        """
+        try:
+            with sqlite3.connect(self.config.path) as conn:
+                cur = conn.cursor()
+                cur.execute("SELECT 1")
+                return True
+        except sqlite3.Error as e:
+            self.log("error", f"Connection test failed: {str(e)}")
+            return False
 
     async def cleanup(self):
         """Cleanup resources"""

--- a/tests/integration/fixtures.py
+++ b/tests/integration/fixtures.py
@@ -18,44 +18,47 @@ from mcp_dbutils.base import ConnectionHandler
 
 class _TestConnectionHandler(ConnectionHandler):
     """Test implementation of ConnectionHandler"""
-    
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         # 禁用自动记录统计信息
         self.stats.record_connection_start = MagicMock()
         self.stats.record_connection_end = MagicMock()
-    
+
     @property
     def db_type(self) -> str:
         return "test"
-        
+
     async def get_tables(self):
         return []
-        
+
     async def get_schema(self, table_name: str):
         return ""
-        
+
     async def _execute_query(self, sql: str):
         return ""
-        
+
     async def get_table_description(self, table_name: str):
         return ""
-        
+
     async def get_table_ddl(self, table_name: str):
         return ""
-        
+
     async def get_table_indexes(self, table_name: str):
         return ""
-        
+
     async def get_table_stats(self, table_name: str):
         return ""
-        
+
     async def get_table_constraints(self, table_name: str):
         return ""
-        
+
     async def explain_query(self, sql: str):
         return ""
-        
+
+    async def test_connection(self) -> bool:
+        return True
+
     async def cleanup(self):
         pass
 
@@ -89,13 +92,13 @@ def mysql_db():
         dbname="test_db",
         root_password="root_pass"
     )
-    
+
     with mysql_container as mysql:
         mysql.start()
-        
+
         # 使用内置的_connect方法等待MySQL完全准备就绪
         mysql._connect()
-        
+
         # 使用mysql-connector-python建立连接
         import mysql.connector as mysql_connector
         conn = mysql_connector.connect(
@@ -105,7 +108,7 @@ def mysql_db():
             password="test_pass",
             database="test_db"
         )
-        
+
         try:
             # 执行数据库初始化脚本
             with conn.cursor() as cursor:
@@ -153,7 +156,7 @@ async def postgres_db() -> AsyncGenerator[Dict[str, str], None]:
                 email TEXT UNIQUE
             );
 
-            INSERT INTO users (name, email) VALUES 
+            INSERT INTO users (name, email) VALUES
                 ('Alice', 'alice@test.com'),
                 ('Bob', 'bob@test.com');
         """)
@@ -190,7 +193,7 @@ async def sqlite_db() -> AsyncGenerator[Dict[str, str], None]:
                 );
             """)
             await db.execute("""
-                INSERT INTO products (name, price) VALUES 
+                INSERT INTO products (name, price) VALUES
                     ('Widget', 9.99),
                     ('Gadget', 19.99);
             """)

--- a/tests/integration/test_list_connections.py
+++ b/tests/integration/test_list_connections.py
@@ -50,21 +50,21 @@ async def test_list_connections_tool(postgres_db, sqlite_db, mcp_config):
                 result = await client.call_tool("dbutils-list-connections", {})
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
-                
+
                 # Check that both connections are listed
                 assert "Connection: test_pg" in result.content[0].text
-                assert "Type: postgresql" in result.content[0].text
+                assert "Type: postgres" in result.content[0].text
                 assert "Connection: test_sqlite" in result.content[0].text
                 assert "Type: sqlite" in result.content[0].text
-                
+
                 # Check that no status is shown when check_status is False
                 assert "Status:" not in result.content[0].text
-                
+
                 # Test list_connections tool with status checking
                 result = await client.call_tool("dbutils-list-connections", {"check_status": True})
                 assert len(result.content) == 1
                 assert result.content[0].type == "text"
-                
+
                 # Check that status is shown when check_status is True
                 assert "Status: Available" in result.content[0].text
 
@@ -87,7 +87,7 @@ async def test_list_connections_empty_config():
     """Test the list_connections tool with an empty configuration"""
     # Create an empty config
     empty_config = {"connections": {}}
-    
+
     with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
         yaml.dump(empty_config, tmp)
         tmp.flush()

--- a/tests/integration/test_list_connections.py
+++ b/tests/integration/test_list_connections.py
@@ -1,0 +1,134 @@
+import asyncio
+import tempfile
+
+import anyio
+import mcp.types as types
+import pytest
+import yaml
+from mcp import ClientSession
+
+from mcp_dbutils.base import ConnectionServer
+from mcp_dbutils.log import create_logger
+
+# 创建测试用的 logger
+logger = create_logger("test-list-connections", True)  # debug=True 以显示所有日志
+
+@pytest.mark.asyncio
+async def test_list_connections_tool(postgres_db, sqlite_db, mcp_config):
+    """Test the list_connections tool with multiple database connections"""
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
+        yaml.dump(mcp_config, tmp)
+        tmp.flush()
+        server = ConnectionServer(config_path=tmp.name)
+
+        # Create bidirectional streams
+        client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)
+        server_to_client_send, server_to_client_recv = anyio.create_memory_object_stream[types.JSONRPCMessage](10)
+
+        # Start server in background
+        server_task = asyncio.create_task(
+            server.server.run(
+                client_to_server_recv,
+                server_to_client_send,
+                server.server.create_initialization_options(),
+                raise_exceptions=True
+            )
+        )
+
+        try:
+            # Initialize client session
+            client = ClientSession(server_to_client_recv, client_to_server_send)
+            async with client:
+                await client.initialize()
+
+                # List available tools
+                response = await client.list_tools()
+                tool_names = [tool.name for tool in response.tools]
+                assert "dbutils-list-connections" in tool_names
+
+                # Test list_connections tool without checking status
+                result = await client.call_tool("dbutils-list-connections", {})
+                assert len(result.content) == 1
+                assert result.content[0].type == "text"
+                
+                # Check that both connections are listed
+                assert "Connection: test_pg" in result.content[0].text
+                assert "Type: postgresql" in result.content[0].text
+                assert "Connection: test_sqlite" in result.content[0].text
+                assert "Type: sqlite" in result.content[0].text
+                
+                # Check that no status is shown when check_status is False
+                assert "Status:" not in result.content[0].text
+                
+                # Test list_connections tool with status checking
+                result = await client.call_tool("dbutils-list-connections", {"check_status": True})
+                assert len(result.content) == 1
+                assert result.content[0].type == "text"
+                
+                # Check that status is shown when check_status is True
+                assert "Status: Available" in result.content[0].text
+
+        finally:
+            # Cleanup
+            server_task.cancel()
+            try:
+                await server_task
+            except asyncio.CancelledError:
+                pass
+
+            # Close streams
+            await client_to_server_send.aclose()
+            await client_to_server_recv.aclose()
+            await server_to_client_send.aclose()
+            await server_to_client_recv.aclose()
+
+@pytest.mark.asyncio
+async def test_list_connections_empty_config():
+    """Test the list_connections tool with an empty configuration"""
+    # Create an empty config
+    empty_config = {"connections": {}}
+    
+    with tempfile.NamedTemporaryFile(mode='w', suffix='.yaml') as tmp:
+        yaml.dump(empty_config, tmp)
+        tmp.flush()
+        server = ConnectionServer(config_path=tmp.name)
+
+        # Create bidirectional streams
+        client_to_server_send, client_to_server_recv = anyio.create_memory_object_stream[types.JSONRPCMessage | Exception](10)
+        server_to_client_send, server_to_client_recv = anyio.create_memory_object_stream[types.JSONRPCMessage](10)
+
+        # Start server in background
+        server_task = asyncio.create_task(
+            server.server.run(
+                client_to_server_recv,
+                server_to_client_send,
+                server.server.create_initialization_options(),
+                raise_exceptions=True
+            )
+        )
+
+        try:
+            # Initialize client session
+            client = ClientSession(server_to_client_recv, client_to_server_send)
+            async with client:
+                await client.initialize()
+
+                # Test list_connections tool with empty config
+                result = await client.call_tool("dbutils-list-connections", {})
+                assert len(result.content) == 1
+                assert result.content[0].type == "text"
+                assert "No database connections found in configuration" in result.content[0].text
+
+        finally:
+            # Cleanup
+            server_task.cancel()
+            try:
+                await server_task
+            except asyncio.CancelledError:
+                pass
+
+            # Close streams
+            await client_to_server_send.aclose()
+            await client_to_server_recv.aclose()
+            await server_to_client_send.aclose()
+            await server_to_client_recv.aclose()

--- a/tests/unit/test_base.py
+++ b/tests/unit/test_base.py
@@ -24,20 +24,20 @@ from mcp_dbutils.base import (
 
 class MockConnectionHandler(ConnectionHandler):
     """Mock implementation of ConnectionHandler for testing"""
-    
+
     def __init__(self, config_path, connection, debug=False):
         super().__init__(config_path, connection, debug)
         self.db_type = "mock"
         self.cleanup_called = False
-    
+
     @property
     def db_type(self) -> str:
         return self._db_type
-    
+
     @db_type.setter
     def db_type(self, value):
         self._db_type = value
-    
+
     async def get_tables(self) -> list[types.Resource]:
         return [
             types.Resource(
@@ -53,7 +53,7 @@ class MockConnectionHandler(ConnectionHandler):
                 mimeType="application/json"
             )
         ]
-    
+
     async def get_schema(self, table_name: str) -> str:
         return json.dumps({
             "columns": [
@@ -61,7 +61,7 @@ class MockConnectionHandler(ConnectionHandler):
                 {"name": "name", "type": "TEXT", "nullable": True}
             ]
         })
-    
+
     async def _execute_query(self, sql: str) -> str:
         if "error" in sql.lower():
             raise ConnectionError("Test query error")
@@ -69,37 +69,45 @@ class MockConnectionHandler(ConnectionHandler):
             "columns": ["id", "name"],
             "rows": [{"id": 1, "name": "Test"}]
         })
-    
+
     async def get_table_description(self, table_name: str) -> str:
         return f"Description for {table_name}"
-    
+
     async def get_table_ddl(self, table_name: str) -> str:
         return f"CREATE TABLE {table_name} (id INTEGER PRIMARY KEY, name TEXT)"
-    
+
     async def get_table_indexes(self, table_name: str) -> str:
         return f"Indexes for {table_name}: idx_name"
-    
+
     async def get_table_stats(self, table_name: str) -> str:
         return f"Stats for {table_name}: 100 rows, 10KB"
-    
+
     async def get_table_constraints(self, table_name: str) -> str:
         return f"Constraints for {table_name}: PRIMARY KEY (id)"
-    
+
     async def explain_query(self, sql: str) -> str:
         return f"Explain plan for: {sql}"
-    
+
+    async def test_connection(self) -> bool:
+        """Test database connection
+
+        Returns:
+            bool: True if connection is successful, False otherwise
+        """
+        return True
+
     async def cleanup(self):
         self.cleanup_called = True
 
 
 class TestConnectionHandler:
     """Test ConnectionHandler abstract base class"""
-    
+
     @pytest.fixture
     def handler(self):
         """Create a mock connection handler"""
         return MockConnectionHandler("/path/to/config.yaml", "test_connection", debug=True)
-    
+
     def test_init(self, handler):
         """Test initialization"""
         assert handler.config_path == "/path/to/config.yaml"
@@ -108,7 +116,7 @@ class TestConnectionHandler:
         assert handler.db_type == "mock"
         assert hasattr(handler, "stats")
         assert hasattr(handler, "log")
-    
+
     @pytest.mark.asyncio
     async def test_execute_query_success(self, handler):
         """Test successful query execution"""
@@ -117,7 +125,7 @@ class TestConnectionHandler:
         assert "rows" in result
         assert handler.stats.query_count == 1
         assert len(handler.stats.query_durations) == 1
-    
+
     @pytest.mark.asyncio
     async def test_execute_query_error(self, handler):
         """Test query execution with error"""
@@ -126,7 +134,7 @@ class TestConnectionHandler:
         assert handler.stats.query_count == 1
         assert len(handler.stats.error_types) == 1
         assert handler.stats.error_types.get("ConnectionError") == 1
-    
+
     @pytest.mark.asyncio
     async def test_execute_tool_query(self, handler):
         """Test tool query execution"""
@@ -134,62 +142,62 @@ class TestConnectionHandler:
         result = await handler.execute_tool_query("dbutils-describe-table", table_name="test_table")
         assert "[mock]" in result
         assert "Description for test_table" in result
-        
+
         # Test get DDL
         result = await handler.execute_tool_query("dbutils-get-ddl", table_name="test_table")
         assert "[mock]" in result
         assert "CREATE TABLE test_table" in result
-        
+
         # Test list indexes
         result = await handler.execute_tool_query("dbutils-list-indexes", table_name="test_table")
         assert "[mock]" in result
         assert "Indexes for test_table" in result
-        
+
         # Test get stats
         result = await handler.execute_tool_query("dbutils-get-stats", table_name="test_table")
         assert "[mock]" in result
         assert "Stats for test_table" in result
-        
+
         # Test list constraints
         result = await handler.execute_tool_query("dbutils-list-constraints", table_name="test_table")
         assert "[mock]" in result
         assert "Constraints for test_table" in result
-        
+
         # Test explain query
         result = await handler.execute_tool_query("dbutils-explain-query", sql="SELECT * FROM test")
         assert "[mock]" in result
         assert "Explain plan for" in result
-    
+
     @pytest.mark.asyncio
     async def test_execute_tool_query_error(self, handler):
         """Test tool query execution with errors"""
         # Test unknown tool
         with pytest.raises(ValueError, match="Unknown tool"):
             await handler.execute_tool_query("unknown-tool")
-        
+
         # Test explain query without SQL
         with pytest.raises(ValueError):
             await handler.execute_tool_query("dbutils-explain-query")
-    
+
     @pytest.mark.asyncio
     async def test_send_log(self, handler):
         """Test send_log method"""
         # Without MCP session
         handler.send_log("info", "Test message")
-        
+
         # With MCP session
         mock_session = MagicMock()
         mock_request_context = MagicMock()
         mock_session.request_context = mock_request_context
         handler._session = mock_session
-        
+
         handler.send_log("error", "Test error message")
         mock_request_context.session.send_log_message.assert_called_once()
 
 
 class TestConnectionServer:
     """Test ConnectionServer class"""
-    
+
     @pytest.fixture
     def mock_config_yaml(self):
         """Mock configuration YAML content"""
@@ -217,37 +225,37 @@ class TestConnectionServer:
           test_missing_type:
             host: localhost
         """
-    
+
     @pytest.fixture
     def server(self):
         """Create a connection server"""
         with patch('builtins.open', mock_open()):
             server = ConnectionServer("/path/to/config.yaml", debug=True)
             return server
-    
+
     def test_init(self, server):
         """Test initialization"""
         assert server.config_path == "/path/to/config.yaml"
         assert server.debug is True
         assert hasattr(server, "server")
         assert hasattr(server, "logger")
-    
+
     def test_send_log(self, server):
         """Test send_log method"""
         # Without MCP session
         server.send_log("info", "Test message")
-        
+
         # With MCP session
         mock_session = MagicMock()
         server.server.session = mock_session
-        
+
         server.send_log("error", "Test error message")
         mock_session.send_log_message.assert_called_once()
-        
+
         # Test with exception
         mock_session.send_log_message.side_effect = Exception("Test exception")
         server.send_log("error", "This should not raise")
-    
+
     @pytest.mark.asyncio
     async def test_get_handler_sqlite(self, server, mock_config_yaml):
         """Test get_handler for SQLite"""
@@ -257,14 +265,14 @@ class TestConnectionServer:
                 mock_handler.stats = MagicMock()
                 mock_handler.cleanup = AsyncMock()
                 mock_handler_class.return_value = mock_handler
-                
+
                 async with server.get_handler("test_sqlite") as handler:
                     assert handler == mock_handler
                     mock_handler_class.assert_called_once_with("/path/to/config.yaml", "test_sqlite", True)
-                
+
                 # Verify cleanup was called
                 mock_handler.cleanup.assert_awaited_once()
-    
+
     @pytest.mark.asyncio
     async def test_get_handler_postgres(self, server, mock_config_yaml):
         """Test get_handler for PostgreSQL"""
@@ -274,14 +282,14 @@ class TestConnectionServer:
                 mock_handler.stats = MagicMock()
                 mock_handler.cleanup = AsyncMock()
                 mock_handler_class.return_value = mock_handler
-                
+
                 async with server.get_handler("test_postgres") as handler:
                     assert handler == mock_handler
                     mock_handler_class.assert_called_once_with("/path/to/config.yaml", "test_postgres", True)
-                
+
                 # Verify cleanup was called
                 mock_handler.cleanup.assert_awaited_once()
-    
+
     @pytest.mark.asyncio
     async def test_get_handler_mysql(self, server, mock_config_yaml):
         """Test get_handler for MySQL"""
@@ -291,14 +299,14 @@ class TestConnectionServer:
                 mock_handler.stats = MagicMock()
                 mock_handler.cleanup = AsyncMock()
                 mock_handler_class.return_value = mock_handler
-                
+
                 async with server.get_handler("test_mysql") as handler:
                     assert handler == mock_handler
                     mock_handler_class.assert_called_once_with("/path/to/config.yaml", "test_mysql", True)
-                
+
                 # Verify cleanup was called
                 mock_handler.cleanup.assert_awaited_once()
-    
+
     @pytest.mark.asyncio
     async def test_get_handler_errors(self, server, mock_config_yaml):
         """Test get_handler with various error conditions"""
@@ -307,32 +315,32 @@ class TestConnectionServer:
              pytest.raises(ConfigurationError, match="Connection not found"):
                 async with server.get_handler("non_existent"):
                     pass
-        
+
         # Test invalid database type
         with patch('builtins.open', mock_open(read_data=mock_config_yaml)), \
              pytest.raises(ConfigurationError, match="Unsupported database type"):
                 async with server.get_handler("test_invalid"):
                     pass
-        
+
         # Test missing type
         with patch('builtins.open', mock_open(read_data=mock_config_yaml)), \
              pytest.raises(ConfigurationError, match="must include 'type' field"):
                 async with server.get_handler("test_missing_type"):
                     pass
-        
+
         # Test invalid YAML
         with patch('builtins.open', mock_open(read_data="invalid_yaml")), \
              pytest.raises(ConfigurationError, match="Configuration file must contain 'connections' section"):
                 async with server.get_handler("test_sqlite"):
                     pass
-        
+
         # Test import error
         with patch('builtins.open', mock_open(read_data=mock_config_yaml)), \
              patch('mcp_dbutils.sqlite.handler.SQLiteHandler', side_effect=ImportError("Test import error")), \
              pytest.raises(ConfigurationError, match="Failed to import handler"):
                     async with server.get_handler("test_sqlite"):
                         pass
-    
+
     @pytest.mark.asyncio
     async def test_handle_list_resources(self, server):
         """Test list_resources handler"""
@@ -340,32 +348,32 @@ class TestConnectionServer:
         mock_handler = AsyncMock()
         mock_tables = [MagicMock(), MagicMock()]
         mock_handler.get_tables.return_value = mock_tables
-        
+
         # 创建一个返回mock_handler的上下文管理器
         @asynccontextmanager
         async def mock_get_handler(connection):
             yield mock_handler
-        
+
         # 打补丁替换server.get_handler
         with patch.object(server, 'get_handler', mock_get_handler):
             # 创建一个模拟的handle_list_resources函数
             async def mock_handle_list_resources(arguments=None):
                 if not arguments or 'connection' not in arguments:
                     return []
-                
+
                 connection = arguments['connection']
                 async with server.get_handler(connection) as handler:
                     return await handler.get_tables()
-            
+
             # 测试无连接情况
             result = await mock_handle_list_resources()
             assert result == []
-            
+
             # 测试有连接情况
             result = await mock_handle_list_resources({"connection": "test_connection"})
             assert result == mock_tables
             mock_handler.get_tables.assert_awaited_once()
-    
+
     @pytest.mark.asyncio
     async def test_handle_read_resource(self, server):
         """Test read_resource handler"""
@@ -373,42 +381,42 @@ class TestConnectionServer:
         mock_handler = AsyncMock()
         mock_schema = '{"columns": [{"name": "id", "type": "INTEGER"}]}'
         mock_handler.get_schema.return_value = mock_schema
-        
+
         # 创建一个返回mock_handler的上下文管理器
         @asynccontextmanager
         async def mock_get_handler(connection):
             yield mock_handler
-        
+
         # 打补丁替换server.get_handler
         with patch.object(server, 'get_handler', mock_get_handler):
             # 创建一个模拟的handle_read_resource函数
             async def mock_handle_read_resource(uri, arguments=None):
                 if not arguments or 'connection' not in arguments:
                     raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-                
+
                 parts = uri.split('/')
                 if len(parts) < 3:
                     raise ConfigurationError(INVALID_URI_FORMAT_ERROR)
-                
+
                 connection = arguments['connection']
                 table_name = parts[-2]  # URI format: xxx/table_name/schema
-                
+
                 async with server.get_handler(connection) as handler:
                     return await handler.get_schema(table_name)
-            
+
             # 测试无连接情况
             with pytest.raises(ConfigurationError, match=CONNECTION_NAME_REQUIRED_ERROR):
                 await mock_handle_read_resource("mock://table/schema")
-            
+
             # 测试无效URI格式
             with pytest.raises(ConfigurationError, match=INVALID_URI_FORMAT_ERROR):
                 await mock_handle_read_resource("invalid_uri", {"connection": "test_connection"})
-            
+
             # 测试有效URI
             result = await mock_handle_read_resource("mock://table1/schema", {"connection": "test_connection"})
             assert result == mock_schema
             mock_handler.get_schema.assert_awaited_once_with("table1")
-    
+
     @pytest.mark.asyncio
     async def test_handle_list_tools(self, server):
         """Test list_tools handler"""
@@ -487,21 +495,21 @@ class TestConnectionServer:
                         }
                     )
                 ]
-            
+
             # 将模拟函数赋值给server
             server._handle_list_tools = mock_handle_list_tools
-        
+
         # Test tool list
         tools = await server._handle_list_tools()
         assert len(tools) > 0
-        
+
         # Verify some specific tools
         tool_names = [tool.name for tool in tools]
         assert "dbutils-run-query" in tool_names
         assert "dbutils-list-tables" in tool_names
         assert "dbutils-describe-table" in tool_names
         assert "dbutils-explain-query" in tool_names
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool(self, server):
         """Test call_tool handler"""
@@ -516,33 +524,33 @@ class TestConnectionServer:
         mock_handler.explain_query.return_value = "Test explain plan"
         mock_handler.stats = MagicMock()
         mock_handler.stats.get_performance_stats.return_value = "Test performance stats"
-        
+
         # 创建一个返回mock_handler的上下文管理器
         @asynccontextmanager
         async def mock_get_handler(connection):
             yield mock_handler
-        
+
         # 打补丁替换server.get_handler
         with patch.object(server, 'get_handler', mock_get_handler):
             # 导入需要的模块
             from datetime import datetime
 
             from mcp_dbutils.base import LOG_LEVEL_ERROR
-            
+
             # 创建一个模拟的handle_call_tool函数
             async def mock_handle_call_tool(name, arguments):
                 if "connection" not in arguments:
                     raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-                
+
                 connection = arguments["connection"]
-                
+
                 if name == "dbutils-list-tables":
                     async with server.get_handler(connection) as handler:
                         tables = await handler.get_tables()
                         if not tables:
                             # 空表列表的情况也返回数据库类型
                             return [types.TextContent(type="text", text=f"[{handler.db_type}] No tables found")]
-                        
+
                         formatted_tables = "\n".join([
                             f"Table: {table.name}\n" +
                             f"URI: {table.uri}\n" +
@@ -556,11 +564,11 @@ class TestConnectionServer:
                     sql = arguments.get("sql", "").strip()
                     if not sql:
                         raise ConfigurationError(EMPTY_QUERY_ERROR)
-                    
+
                     # Only allow SELECT statements
                     if not sql.lower().startswith("select"):
                         raise ConfigurationError(SELECT_ONLY_ERROR)
-                    
+
                     async with server.get_handler(connection) as handler:
                         result = await handler.execute_query(sql)
                         return [types.TextContent(type="text", text=result)]
@@ -569,7 +577,7 @@ class TestConnectionServer:
                     table = arguments.get("table", "").strip()
                     if not table:
                         raise ConfigurationError(EMPTY_TABLE_NAME_ERROR)
-                    
+
                     async with server.get_handler(connection) as handler:
                         result = await handler.execute_tool_query(name, table_name=table)
                         return [types.TextContent(type="text", text=result)]
@@ -577,7 +585,7 @@ class TestConnectionServer:
                     sql = arguments.get("sql", "").strip()
                     if not sql:
                         raise ConfigurationError(EMPTY_QUERY_ERROR)
-                    
+
                     async with server.get_handler(connection) as handler:
                         result = await handler.execute_tool_query(name, sql=sql)
                         return [types.TextContent(type="text", text=result)]
@@ -589,11 +597,11 @@ class TestConnectionServer:
                     sql = arguments.get("sql", "").strip()
                     if not sql:
                         raise ConfigurationError(EMPTY_QUERY_ERROR)
-                    
+
                     async with server.get_handler(connection) as handler:
                         # First get the execution plan
                         explain_result = await handler.explain_query(sql)
-                        
+
                         # Then execute the actual query to measure performance
                         start_time = datetime.now()
                         if sql.lower().startswith("select"):
@@ -603,7 +611,7 @@ class TestConnectionServer:
                                 # If query fails, we still provide the execution plan
                                 server.send_log(LOG_LEVEL_ERROR, f"Query execution failed during analysis: {str(e)}")
                         duration = (datetime.now() - start_time).total_seconds()
-                        
+
                         # Combine analysis results
                         analysis = [
                         f"[{handler.db_type}] Query Analysis",
@@ -614,7 +622,7 @@ class TestConnectionServer:
                         "Execution Plan:",
                             explain_result
                         ]
-                        
+
                         # Add optimization suggestions based on execution plan and timing
                         suggestions = []
                         if "seq scan" in explain_result.lower() and duration > 0.1:
@@ -625,19 +633,19 @@ class TestConnectionServer:
                             suggestions.append("- Query is slow, consider optimizing or adding caching")
                         if "temporary" in explain_result.lower():
                             suggestions.append("- Query creates temporary tables, consider restructuring")
-                        
+
                         if suggestions:
                             analysis.append("\nOptimization Suggestions:")
                             analysis.extend(suggestions)
-                            
+
                         return [types.TextContent(type="text", text="\n".join(analysis))]
                 else:
                     raise ConfigurationError(f"Unknown tool: {name}")
-            
+
             # 测试无连接情况
             with pytest.raises(ConfigurationError, match=CONNECTION_NAME_REQUIRED_ERROR):
                 await mock_handle_call_tool("dbutils-run-query", {})
-            
+
             # 测试dbutils-list-tables
             result = await mock_handle_call_tool("dbutils-list-tables", {"connection": "test_connection"})
             assert len(result) == 1
@@ -645,14 +653,14 @@ class TestConnectionServer:
             assert "[mock]" in result[0].text
             assert "Table: Table 1" in result[0].text
             mock_handler.get_tables.assert_awaited_once()
-            
+
             # 测试dbutils-list-tables空结果
             mock_handler.get_tables.reset_mock()
             mock_handler.get_tables.return_value = []
             result = await mock_handle_call_tool("dbutils-list-tables", {"connection": "test_connection"})
             assert len(result) == 1
             assert "No tables found" in result[0].text
-            
+
             # 测试dbutils-run-query
             result = await mock_handle_call_tool("dbutils-run-query", {
                 "connection": "test_connection",
@@ -661,21 +669,21 @@ class TestConnectionServer:
             assert len(result) == 1
             assert result[0].text == '{"columns": ["id"], "rows": [{"id": 1}]}'
             mock_handler.execute_query.assert_awaited_once_with("SELECT * FROM test")
-            
+
             # 测试dbutils-run-query空SQL
             with pytest.raises(ConfigurationError, match=EMPTY_QUERY_ERROR):
                 await mock_handle_call_tool("dbutils-run-query", {
                     "connection": "test_connection",
                     "sql": ""
                 })
-            
+
             # 测试dbutils-run-query非SELECT SQL
             with pytest.raises(ConfigurationError, match=SELECT_ONLY_ERROR):
                 await mock_handle_call_tool("dbutils-run-query", {
                     "connection": "test_connection",
                     "sql": "DELETE FROM test"
                 })
-            
+
             # 测试dbutils-describe-table
             result = await mock_handle_call_tool("dbutils-describe-table", {
                 "connection": "test_connection",
@@ -684,7 +692,7 @@ class TestConnectionServer:
             assert len(result) == 1
             assert result[0].text == "[mock]\nTest result"
             mock_handler.execute_tool_query.assert_awaited_once_with("dbutils-describe-table", table_name="test_table")
-            
+
             # 测试dbutils-describe-table空表名
             mock_handler.execute_tool_query.reset_mock()
             with pytest.raises(ConfigurationError, match=EMPTY_TABLE_NAME_ERROR):
@@ -692,7 +700,7 @@ class TestConnectionServer:
                     "connection": "test_connection",
                     "table": ""
                 })
-            
+
             # 测试dbutils-explain-query
             mock_handler.execute_tool_query.reset_mock()
             result = await mock_handle_call_tool("dbutils-explain-query", {
@@ -702,7 +710,7 @@ class TestConnectionServer:
             assert len(result) == 1
             assert result[0].text == "[mock]\nTest result"
             mock_handler.execute_tool_query.assert_awaited_once_with("dbutils-explain-query", sql="SELECT * FROM test")
-            
+
             # 测试dbutils-get-performance
             result = await mock_handle_call_tool("dbutils-get-performance", {
                 "connection": "test_connection"
@@ -710,7 +718,7 @@ class TestConnectionServer:
             assert len(result) == 1
             assert "[mock]" in result[0].text
             assert "Test performance stats" in result[0].text
-            
+
             # 测试dbutils-analyze-query
             result = await mock_handle_call_tool("dbutils-analyze-query", {
                 "connection": "test_connection",
@@ -722,11 +730,11 @@ class TestConnectionServer:
             assert "Execution Plan:" in result[0].text
             mock_handler.explain_query.assert_awaited_once_with("SELECT * FROM test")
             mock_handler.execute_query.assert_awaited()
-            
+
             # 测试未知工具
             with pytest.raises(ConfigurationError, match="Unknown tool"):
                 await mock_handle_call_tool("unknown-tool", {"connection": "test_connection"})
-    
+
     @pytest.mark.asyncio
     async def test_handle_list_prompts(self, server):
         """Test list_prompts handler"""
@@ -736,14 +744,14 @@ class TestConnectionServer:
             # 创建一个模拟的handle_list_prompts函数
             async def mock_handle_list_prompts():
                 return []
-            
+
             # 将模拟函数赋值给server
             server._handle_list_prompts = mock_handle_list_prompts
-        
+
         # Test normal operation
         result = await server._handle_list_prompts()
         assert result == []
-        
+
         # Test with exception
         with patch.object(server, 'send_log') as mock_send_log, \
              patch.object(server, '_handle_list_prompts', side_effect=Exception("Test exception")), \

--- a/tests/unit/test_base_server.py
+++ b/tests/unit/test_base_server.py
@@ -36,13 +36,13 @@ class TestConnectionServerPrompts:
         async def mock_list_prompts():
             connection_server.send_log()
             return []
-        
+
         # Call the mock function
         result = await mock_list_prompts()
         assert isinstance(result, list)
         assert len(result) == 0
         connection_server.send_log.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_list_prompts_exception(self, connection_server):
         """Test the list_prompts handler handles exceptions"""
@@ -50,31 +50,31 @@ class TestConnectionServerPrompts:
         async def mock_list_prompts_with_exception():
             connection_server.send_log()
             raise ValueError("Test exception")
-        
+
         # Call the mock function and expect an exception
         with pytest.raises(ValueError, match="Test exception"):
             await mock_list_prompts_with_exception()
-        
+
         # Verify that send_log was called
         connection_server.send_log.assert_called_once()
-    
+
     def test_setup_prompts(self, connection_server):
         """Test the _setup_prompts method sets up the handler correctly"""
         # Mock the server.list_prompts decorator
         mock_decorator = MagicMock()
         mock_decorator.return_value = lambda f: f  # Return the function unchanged
-        
+
         # Replace the server.list_prompts with our mock
         original_list_prompts = connection_server.server.list_prompts
         connection_server.server.list_prompts = mock_decorator
-        
+
         try:
             # Call the method
             connection_server._setup_prompts()
-            
+
             # Verify the decorator was called
             assert mock_decorator.called, "Decorator should have been called"
-            
+
             # Get the args from the most recent call
             if mock_decorator.call_args:  # Check if call_args exists first
                 # If it was called with positional arguments
@@ -100,51 +100,51 @@ class TestConnectionServerPrompts:
         # Mock the decorator to capture the decorated function
         original_list_prompts = connection_server.server.list_prompts
         captured_handler = None
-        
+
         def mock_decorator():
             def wrapper(func):
                 nonlocal captured_handler
                 captured_handler = func
                 return func
             return wrapper
-        
+
         # Replace the decorator with our mock
         connection_server.server.list_prompts = mock_decorator
-        
+
         try:
             # Call the method to set up the handler
             connection_server._setup_prompts()
-            
+
             # Now we have captured the handler, restore the original decorator
             connection_server.server.list_prompts = original_list_prompts
-            
+
             # Make sure we captured the handler
             assert captured_handler is not None
-            
+
             # Setup mocks for testing exception flow
             connection_server.send_log = MagicMock()
-            
+
             # Create a test exception that will be raised in the try block
             test_exception = ValueError("Test error in list_prompts")
-            
+
             # Mock the self.send_log in the try block to raise an exception after being called
             def mock_send_log_and_raise(*args, **kwargs):
                 # First call during normal operation (debug log)
                 if args[0] == LOG_LEVEL_DEBUG:
                     # After logging debug, simulate an error
                     raise test_exception
-            
+
             connection_server.send_log.side_effect = mock_send_log_and_raise
-            
+
             # Call the handler and expect the exception to be caught and logged, then re-raised
             with pytest.raises(ValueError, match="Test error in list_prompts"):
                 await captured_handler()
-            
+
             # Check that both the debug log and the error log were called
             assert connection_server.send_log.call_count == 2
             connection_server.send_log.assert_any_call(LOG_LEVEL_DEBUG, "Handling list_prompts request")
             connection_server.send_log.assert_any_call(LOG_LEVEL_ERROR, f"Error in list_prompts: {test_exception}")
-            
+
         finally:
             # Make sure we always restore the original decorator
             connection_server.server.list_prompts = original_list_prompts
@@ -156,11 +156,16 @@ class TestConnectionServerTools:
         tools = connection_server._get_available_tools()
         assert isinstance(tools, list)
         assert len(tools) > 0
-        
-        # Verify the first tool is dbutils-run-query
-        assert tools[0].name == "dbutils-run-query"
-        assert "Execute read-only SQL query" in tools[0].description
-        
+
+        # Verify the first tool is dbutils-list-connections
+        assert tools[0].name == "dbutils-list-connections"
+        assert "List all available database connections" in tools[0].description
+
+        # Verify dbutils-run-query is also in the tools
+        run_query_tools = [tool for tool in tools if tool.name == "dbutils-run-query"]
+        assert len(run_query_tools) == 1
+        assert "Execute read-only SQL query" in run_query_tools[0].description
+
         # Check that all tools have the required properties
         for tool in tools:
             assert isinstance(tool, types.Tool)
@@ -177,21 +182,21 @@ class TestConnectionServerHandlers:
         async def mock_handle_list_resources(arguments=None):
             if not arguments or 'connection' not in arguments:
                 return []
-            
+
             connection = arguments['connection']
             async with connection_server.get_handler(connection) as handler:
                 return await handler.get_tables()
-        
+
         # Test with no arguments
         result = await mock_handle_list_resources()
         assert isinstance(result, list)
         assert len(result) == 0
-        
+
         # Test with empty arguments
         result = await mock_handle_list_resources({})
         assert isinstance(result, list)
         assert len(result) == 0
-    
+
     @pytest.mark.asyncio
     async def test_handle_list_resources_with_connection(self, connection_server):
         """Test list_resources handler with connection argument"""
@@ -212,26 +217,26 @@ class TestConnectionServerHandlers:
             )
         ]
         connection_server.get_handler = MagicMock(return_value=mock_handler)
-        
+
         # Create a mock list_resources handler function
         async def mock_handle_list_resources(arguments=None):
             if not arguments or 'connection' not in arguments:
                 return []
-            
+
             connection = arguments['connection']
             async with connection_server.get_handler(connection) as handler:
                 return await handler.get_tables()
-        
+
         # Test with connection argument
         result = await mock_handle_list_resources({"connection": "test_conn"})
         assert isinstance(result, list)
         assert len(result) == 2
         assert result[0].name == "table1"
         assert result[1].name == "table2"
-        
+
         connection_server.get_handler.assert_called_once_with("test_conn")
         mock_handler.__aenter__.return_value.get_tables.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_handle_list_resources_exception(self, connection_server):
         """Test list_resources handler with an exception"""
@@ -240,7 +245,7 @@ class TestConnectionServerHandlers:
         mock_handler.__aenter__.return_value.get_tables.side_effect = ValueError("Test exception")
         connection_server.get_handler = MagicMock(return_value=mock_handler)
         connection_server.send_log = MagicMock()
-        
+
         # Create a mock list_resources handler function with exception handling
         async def mock_handle_list_resources(arguments=None):
             if not arguments or 'connection' not in arguments:
@@ -255,15 +260,15 @@ class TestConnectionServerHandlers:
                 connection_server.send_log(LOG_LEVEL_ERROR, f"Error in list_resources: {str(e)}")
                 # Re-raise to test exception handling
                 raise
-        
+
         # Test with connection argument that raises an exception
         with pytest.raises(ValueError, match="Test exception"):
             await mock_handle_list_resources({"connection": "test_conn"})
-        
+
         connection_server.get_handler.assert_called_once_with("test_conn")
         mock_handler.__aenter__.return_value.get_tables.assert_called_once()
         connection_server.send_log.assert_called_once_with(LOG_LEVEL_ERROR, "Error in list_resources: Test exception")
-    
+
     @pytest.mark.asyncio
     async def test_handle_read_resource_no_connection(self, connection_server):
         """Test read_resource handler with no connection argument"""
@@ -271,25 +276,25 @@ class TestConnectionServerHandlers:
         async def mock_handle_read_resource(uri, arguments=None):
             if not arguments or 'connection' not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             parts = uri.split('/')
             if len(parts) < 3:
                 raise ConfigurationError(INVALID_URI_FORMAT_ERROR)
-            
+
             connection = arguments['connection']
             table_name = parts[-2]  # URI format: xxx/table_name/schema
-            
+
             async with connection_server.get_handler(connection) as handler:
                 return await handler.get_schema(table_name)
-        
+
         # Test with no arguments
         with pytest.raises(ConfigurationError, match=CONNECTION_NAME_REQUIRED_ERROR):
             await mock_handle_read_resource("mock://table/schema", None)
-        
+
         # Test with empty arguments
         with pytest.raises(ConfigurationError, match=CONNECTION_NAME_REQUIRED_ERROR):
             await mock_handle_read_resource("mock://table/schema", {})
-    
+
     @pytest.mark.asyncio
     async def test_handle_read_resource_invalid_uri(self, connection_server):
         """Test read_resource handler with invalid URI format"""
@@ -297,21 +302,21 @@ class TestConnectionServerHandlers:
         async def mock_handle_read_resource(uri, arguments=None):
             if not arguments or 'connection' not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             parts = uri.split('/')
             if len(parts) < 3:
                 raise ConfigurationError(INVALID_URI_FORMAT_ERROR)
-            
+
             connection = arguments['connection']
             table_name = parts[-2]  # URI format: xxx/table_name/schema
-            
+
             async with connection_server.get_handler(connection) as handler:
                 return await handler.get_schema(table_name)
-        
+
         # Test with invalid URI
         with pytest.raises(ConfigurationError, match=INVALID_URI_FORMAT_ERROR):
             await mock_handle_read_resource("invalid", {"connection": "test_conn"})
-    
+
     @pytest.mark.asyncio
     async def test_handle_read_resource_valid(self, connection_server):
         """Test read_resource handler with valid arguments"""
@@ -319,29 +324,29 @@ class TestConnectionServerHandlers:
         mock_handler = AsyncMock()
         mock_handler.__aenter__.return_value.get_schema.return_value = "table schema"
         connection_server.get_handler = MagicMock(return_value=mock_handler)
-        
+
         # Create a mock read_resource handler function
         async def mock_handle_read_resource(uri, arguments=None):
             if not arguments or 'connection' not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             parts = uri.split('/')
             if len(parts) < 3:
                 raise ConfigurationError(INVALID_URI_FORMAT_ERROR)
-            
+
             connection = arguments['connection']
             table_name = parts[-2]  # URI format: xxx/table_name/schema
-            
+
             async with connection_server.get_handler(connection) as handler:
                 return await handler.get_schema(table_name)
-        
+
         # Test with valid arguments
         result = await mock_handle_read_resource("mock://table1/schema", {"connection": "test_conn"})
         assert result == "table schema"
-        
+
         connection_server.get_handler.assert_called_once_with("test_conn")
         mock_handler.__aenter__.return_value.get_schema.assert_called_once_with("table1")
-    
+
     @pytest.mark.asyncio
     async def test_handle_read_resource_exception(self, connection_server):
         """Test read_resource handler with an exception"""
@@ -350,7 +355,7 @@ class TestConnectionServerHandlers:
         mock_handler.__aenter__.return_value.get_schema.side_effect = ValueError("Test exception")
         connection_server.get_handler = MagicMock(return_value=mock_handler)
         connection_server.send_log = MagicMock()
-        
+
         # Create a mock read_resource handler function with exception handling
         async def mock_handle_read_resource(uri, arguments=None):
             if not arguments or 'connection' not in arguments:
@@ -370,31 +375,31 @@ class TestConnectionServerHandlers:
                 connection_server.send_log(LOG_LEVEL_ERROR, f"Error in read_resource: {str(e)}")
                 # Re-raise to test exception handling
                 raise
-        
+
         # Test with arguments that raise an exception
         with pytest.raises(ValueError, match="Test exception"):
             await mock_handle_read_resource("mock://table1/schema", {"connection": "test_conn"})
-        
+
         connection_server.get_handler.assert_called_once_with("test_conn")
         mock_handler.__aenter__.return_value.get_schema.assert_called_once_with("table1")
         connection_server.send_log.assert_called_once_with(LOG_LEVEL_ERROR, "Error in read_resource: Test exception")
-    
+
     @pytest.mark.asyncio
     async def test_handle_list_tools(self, connection_server):
         """Test list_tools handler returns available tools"""
         # Mock the _get_available_tools method
         mock_tools = [types.Tool(name="test-tool", description="Test tool", inputSchema={})]
         connection_server._get_available_tools = MagicMock(return_value=mock_tools)
-        
+
         # Create a mock list_tools handler function
         async def mock_handle_list_tools():
             return connection_server._get_available_tools()
-        
+
         # Test the function
         result = await mock_handle_list_tools()
         assert result == mock_tools
         connection_server._get_available_tools.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_no_connection(self, connection_server):
         """Test call_tool handler with no connection argument"""
@@ -402,9 +407,9 @@ class TestConnectionServerHandlers:
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-list-tables":
                 return await connection_server._handle_list_tables(connection)
             elif name == "dbutils-run-query":
@@ -424,11 +429,11 @@ class TestConnectionServerHandlers:
                 return await connection_server._handle_analyze_query(connection, sql)
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with no connection
         with pytest.raises(ConfigurationError, match=CONNECTION_NAME_REQUIRED_ERROR):
             await mock_handle_call_tool("dbutils-run-query", {})
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_unknown_tool(self, connection_server):
         """Test call_tool handler with unknown tool name"""
@@ -436,9 +441,9 @@ class TestConnectionServerHandlers:
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-list-tables":
                 return await connection_server._handle_list_tables(connection)
             elif name == "dbutils-run-query":
@@ -458,73 +463,73 @@ class TestConnectionServerHandlers:
                 return await connection_server._handle_analyze_query(connection, sql)
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with unknown tool
         with pytest.raises(ConfigurationError, match="Unknown tool: unknown-tool"):
             await mock_handle_call_tool("unknown-tool", {"connection": "test_conn"})
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_list_tables(self, connection_server):
         """Test call_tool handler with dbutils-list-tables tool"""
         # Mock the _handle_list_tables method
         expected_result = [types.TextContent(type="text", text="Table list")]
         connection_server._handle_list_tables = AsyncMock(return_value=expected_result)
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-list-tables":
                 return await connection_server._handle_list_tables(connection)
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with list-tables tool
         result = await mock_handle_call_tool("dbutils-list-tables", {"connection": "test_conn"})
         assert result == expected_result
         connection_server._handle_list_tables.assert_called_once_with("test_conn")
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_run_query(self, connection_server):
         """Test call_tool handler with dbutils-run-query tool"""
         # Mock the _handle_run_query method
         expected_result = [types.TextContent(type="text", text="Query result")]
         connection_server._handle_run_query = AsyncMock(return_value=expected_result)
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-run-query":
                 sql = arguments.get("sql", "").strip()
                 return await connection_server._handle_run_query(connection, sql)
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with run-query tool
         result = await mock_handle_call_tool("dbutils-run-query", {"connection": "test_conn", "sql": "SELECT 1"})
         assert result == expected_result
         connection_server._handle_run_query.assert_called_once_with("test_conn", "SELECT 1")
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_run_query_exception(self, connection_server):
         """Test call_tool handler with dbutils-run-query tool when an exception occurs"""
         # Mock the _handle_run_query method to raise an exception
         connection_server._handle_run_query = AsyncMock(side_effect=ValueError("Test exception"))
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-run-query":
                 sql = arguments.get("sql", "").strip()
                 try:
@@ -535,63 +540,63 @@ class TestConnectionServerHandlers:
                     raise
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with run-query tool that raises an exception
         with pytest.raises(ValueError, match="Test exception"):
             await mock_handle_call_tool("dbutils-run-query", {"connection": "test_conn", "sql": "SELECT 1"})
-        
+
         # Verify that _handle_run_query was called and send_log was called for the error
         connection_server._handle_run_query.assert_called_once_with("test_conn", "SELECT 1")
         connection_server.send_log.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_table_tools(self, connection_server):
         """Test call_tool handler with table-related tools"""
         # Mock the _handle_table_tools method
         expected_result = [types.TextContent(type="text", text="Table info")]
         connection_server._handle_table_tools = AsyncMock(return_value=expected_result)
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name in ["dbutils-describe-table", "dbutils-get-ddl", "dbutils-list-indexes",
                        "dbutils-get-stats", "dbutils-list-constraints"]:
                 table = arguments.get("table", "").strip()
                 return await connection_server._handle_table_tools(name, connection, table)
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with table tools
         table_tools = [
-            "dbutils-describe-table", 
-            "dbutils-get-ddl", 
+            "dbutils-describe-table",
+            "dbutils-get-ddl",
             "dbutils-list-indexes",
-            "dbutils-get-stats", 
+            "dbutils-get-stats",
             "dbutils-list-constraints"
         ]
-        
+
         for tool in table_tools:
             result = await mock_handle_call_tool(tool, {"connection": "test_conn", "table": "users"})
             assert result == expected_result
             connection_server._handle_table_tools.assert_called_with(tool, "test_conn", "users")
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_table_tools_exception(self, connection_server):
         """Test call_tool handler with table-related tools when an exception occurs"""
         # Mock the _handle_table_tools method to raise an exception
         connection_server._handle_table_tools = AsyncMock(side_effect=ValueError("Test exception"))
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name in ["dbutils-describe-table", "dbutils-get-ddl", "dbutils-list-indexes",
                        "dbutils-get-stats", "dbutils-list-constraints"]:
                 table = arguments.get("table", "").strip()
@@ -603,53 +608,53 @@ class TestConnectionServerHandlers:
                     raise
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with table tool that raises an exception
         with pytest.raises(ValueError, match="Test exception"):
             await mock_handle_call_tool("dbutils-describe-table", {"connection": "test_conn", "table": "users"})
-        
+
         # Verify that _handle_table_tools was called and send_log was called for the error
         connection_server._handle_table_tools.assert_called_once_with("dbutils-describe-table", "test_conn", "users")
         connection_server.send_log.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_explain_query(self, connection_server):
         """Test call_tool handler with dbutils-explain-query tool"""
         # Mock the _handle_explain_query method
         expected_result = [types.TextContent(type="text", text="Query explanation")]
         connection_server._handle_explain_query = AsyncMock(return_value=expected_result)
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-explain-query":
                 sql = arguments.get("sql", "").strip()
                 return await connection_server._handle_explain_query(connection, sql)
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with explain-query tool
         result = await mock_handle_call_tool("dbutils-explain-query", {"connection": "test_conn", "sql": "SELECT 1"})
         assert result == expected_result
         connection_server._handle_explain_query.assert_called_once_with("test_conn", "SELECT 1")
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_explain_query_exception(self, connection_server):
         """Test call_tool handler with dbutils-explain-query tool when an exception occurs"""
         # Mock the _handle_explain_query method to raise an exception
         connection_server._handle_explain_query = AsyncMock(side_effect=ValueError("Test exception"))
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-explain-query":
                 sql = arguments.get("sql", "").strip()
                 try:
@@ -660,52 +665,52 @@ class TestConnectionServerHandlers:
                     raise
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with explain-query tool that raises an exception
         with pytest.raises(ValueError, match="Test exception"):
             await mock_handle_call_tool("dbutils-explain-query", {"connection": "test_conn", "sql": "SELECT 1"})
-        
+
         # Verify that _handle_explain_query was called and send_log was called for the error
         connection_server._handle_explain_query.assert_called_once_with("test_conn", "SELECT 1")
         connection_server.send_log.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_get_performance(self, connection_server):
         """Test call_tool handler with dbutils-get-performance tool"""
         # Mock the _handle_performance method
         expected_result = [types.TextContent(type="text", text="Performance info")]
         connection_server._handle_performance = AsyncMock(return_value=expected_result)
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-get-performance":
                 return await connection_server._handle_performance(connection)
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with get-performance tool
         result = await mock_handle_call_tool("dbutils-get-performance", {"connection": "test_conn"})
         assert result == expected_result
         connection_server._handle_performance.assert_called_once_with("test_conn")
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_get_performance_exception(self, connection_server):
         """Test call_tool handler with dbutils-get-performance tool when an exception occurs"""
         # Mock the _handle_performance method to raise an exception
         connection_server._handle_performance = AsyncMock(side_effect=ValueError("Test exception"))
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-get-performance":
                 try:
                     return await connection_server._handle_performance(connection)
@@ -715,53 +720,53 @@ class TestConnectionServerHandlers:
                     raise
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with get-performance tool that raises an exception
         with pytest.raises(ValueError, match="Test exception"):
             await mock_handle_call_tool("dbutils-get-performance", {"connection": "test_conn"})
-        
+
         # Verify that _handle_performance was called and send_log was called for the error
         connection_server._handle_performance.assert_called_once_with("test_conn")
         connection_server.send_log.assert_called_once()
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_analyze_query(self, connection_server):
         """Test call_tool handler with dbutils-analyze-query tool"""
         # Mock the _handle_analyze_query method
         expected_result = [types.TextContent(type="text", text="Query analysis")]
         connection_server._handle_analyze_query = AsyncMock(return_value=expected_result)
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-analyze-query":
                 sql = arguments.get("sql", "").strip()
                 return await connection_server._handle_analyze_query(connection, sql)
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with analyze-query tool
         result = await mock_handle_call_tool("dbutils-analyze-query", {"connection": "test_conn", "sql": "SELECT 1"})
         assert result == expected_result
         connection_server._handle_analyze_query.assert_called_once_with("test_conn", "SELECT 1")
-    
+
     @pytest.mark.asyncio
     async def test_handle_call_tool_analyze_query_exception(self, connection_server):
         """Test call_tool handler with dbutils-analyze-query tool when an exception occurs"""
         # Mock the _handle_analyze_query method to raise an exception
         connection_server._handle_analyze_query = AsyncMock(side_effect=ValueError("Test exception"))
-        
+
         # Create a mock call_tool handler function
         async def mock_handle_call_tool(name, arguments):
             if "connection" not in arguments:
                 raise ConfigurationError(CONNECTION_NAME_REQUIRED_ERROR)
-            
+
             connection = arguments["connection"]
-            
+
             if name == "dbutils-analyze-query":
                 sql = arguments.get("sql", "").strip()
                 try:
@@ -772,11 +777,11 @@ class TestConnectionServerHandlers:
                     raise
             else:
                 raise ConfigurationError(f"Unknown tool: {name}")
-        
+
         # Test with analyze-query tool that raises an exception
         with pytest.raises(ValueError, match="Test exception"):
             await mock_handle_call_tool("dbutils-analyze-query", {"connection": "test_conn", "sql": "SELECT 1"})
-        
+
         # Verify that _handle_analyze_query was called and send_log was called for the error
         connection_server._handle_analyze_query.assert_called_once_with("test_conn", "SELECT 1")
         connection_server.send_log.assert_called_once()
@@ -786,56 +791,56 @@ class TestConnectionServerHandlers:
         # Mock the server decorators
         mock_list_resources = MagicMock()
         mock_list_resources.return_value = lambda f: f  # Return the function unchanged
-        
+
         mock_read_resource = MagicMock()
         mock_read_resource.return_value = lambda f: f
-        
+
         mock_list_tools = MagicMock()
         mock_list_tools.return_value = lambda f: f
-        
+
         mock_call_tool = MagicMock()
         mock_call_tool.return_value = lambda f: f
-        
+
         # Store original decorators
         original_list_resources = connection_server.server.list_resources
         original_read_resource = connection_server.server.read_resource
         original_list_tools = connection_server.server.list_tools
         original_call_tool = connection_server.server.call_tool
-        
+
         # Replace with mocks
         connection_server.server.list_resources = mock_list_resources
         connection_server.server.read_resource = mock_read_resource
         connection_server.server.list_tools = mock_list_tools
         connection_server.server.call_tool = mock_call_tool
-        
+
         try:
             # Call the method
             connection_server._setup_handlers()
-            
+
             # Verify all decorators were called
             assert mock_list_resources.called, "list_resources decorator should have been called"
             assert mock_read_resource.called, "read_resource decorator should have been called"
             assert mock_list_tools.called, "list_tools decorator should have been called"
             assert mock_call_tool.called, "call_tool decorator should have been called"
-            
+
             # Verify handle_list_resources function
             if mock_list_resources.call_args and mock_list_resources.call_args.args:
                 handler = mock_list_resources.call_args.args[0]
                 assert callable(handler)
                 assert handler.__name__ == "handle_list_resources"
-            
+
             # Verify handle_read_resource function
             if mock_read_resource.call_args and mock_read_resource.call_args.args:
                 handler = mock_read_resource.call_args.args[0]
                 assert callable(handler)
                 assert handler.__name__ == "handle_read_resource"
-            
+
             # Verify handle_list_tools function
             if mock_list_tools.call_args and mock_list_tools.call_args.args:
                 handler = mock_list_tools.call_args.args[0]
                 assert callable(handler)
                 assert handler.__name__ == "handle_list_tools"
-            
+
             # Verify handle_call_tool function
             if mock_call_tool.call_args and mock_call_tool.call_args.args:
                 handler = mock_call_tool.call_args.args[0]
@@ -854,35 +859,35 @@ class TestConnectionServerHandlers:
         # Mock the decorators to capture the decorated functions
         original_list_resources = connection_server.server.list_resources
         captured_list_resources = None
-        
+
         def mock_list_resources_decorator():
             def wrapper(func):
                 nonlocal captured_list_resources
                 captured_list_resources = func
                 return func
             return wrapper
-        
+
         # Replace decorators with mocks
         connection_server.server.list_resources = mock_list_resources_decorator
-        
+
         try:
             # Call setup_handlers to register handlers
             connection_server._setup_handlers()
-            
+
             # Restore the decorators
             connection_server.server.list_resources = original_list_resources
-            
+
             # Validate we captured the handlers
             assert captured_list_resources is not None
-            
+
             # Use the original self reference from the captured function
             # Store the original self object
             original_self = connection_server
-            
+
             # Prepare mocks
             mock_handler = AsyncMock()
             mock_handler.get_tables = AsyncMock(side_effect=ValueError("DB error"))
-            
+
             # Define a custom async context manager for testing
             @asynccontextmanager
             async def mock_get_handler(connection_name):
@@ -890,16 +895,16 @@ class TestConnectionServerHandlers:
                     yield mock_handler
                 finally:
                     pass
-            
+
             # Replace the get_handler method
             original_get_handler = original_self.get_handler
             original_self.get_handler = mock_get_handler
-            
+
             try:
                 # The function should raise the exception
                 with pytest.raises(ValueError, match="DB error"):
                     await captured_list_resources({"connection": "test_conn"})
-                
+
                 # Verify mock_handler's get_tables was called
                 mock_handler.get_tables.assert_called_once()
             finally:
@@ -908,42 +913,42 @@ class TestConnectionServerHandlers:
         finally:
             # Always restore the original decorator
             connection_server.server.list_resources = original_list_resources
-    
+
     @pytest.mark.asyncio
     async def test_setup_handlers_read_resource_exception(self, connection_server):
         """Test the exception handling in handle_read_resource function from _setup_handlers"""
         # Mock the decorators to capture the decorated functions
         original_read_resource = connection_server.server.read_resource
         captured_read_resource = None
-        
+
         def mock_read_resource_decorator():
             def wrapper(func):
                 nonlocal captured_read_resource
                 captured_read_resource = func
                 return func
             return wrapper
-        
+
         # Replace decorators with mocks
         connection_server.server.read_resource = mock_read_resource_decorator
-        
+
         try:
             # Call setup_handlers to register handlers
             connection_server._setup_handlers()
-            
+
             # Restore the decorators
             connection_server.server.read_resource = original_read_resource
-            
+
             # Validate we captured the handlers
             assert captured_read_resource is not None
-            
+
             # Use the original self reference from the captured function
             # Store the original self object
             original_self = connection_server
-            
+
             # Prepare mocks
             mock_handler = AsyncMock()
             mock_handler.get_schema = AsyncMock(side_effect=ValueError("Schema error"))
-            
+
             # Define a custom async context manager for testing
             @asynccontextmanager
             async def mock_get_handler(connection_name):
@@ -951,16 +956,16 @@ class TestConnectionServerHandlers:
                     yield mock_handler
                 finally:
                     pass
-            
+
             # Replace the get_handler method
             original_get_handler = original_self.get_handler
             original_self.get_handler = mock_get_handler
-            
+
             try:
                 # The function should raise the exception
                 with pytest.raises(ValueError, match="Schema error"):
                     await captured_read_resource("mock://table1/schema", {"connection": "test_conn"})
-                
+
                 # Verify mock_handler's get_schema was called
                 mock_handler.get_schema.assert_called_once_with("table1")
             finally:
@@ -982,18 +987,18 @@ class TestConnectionServerRun:
         mock_context_manager = AsyncMock()
         mock_context_manager.__aenter__.return_value = [mock_stdin, mock_stdout]
         mock_stdio_server.return_value = mock_context_manager
-        
+
         # Mock the server.run method to avoid validation errors
         connection_server.server.run = AsyncMock()
-        
+
         # Call the run method
         await connection_server.run()
-        
+
         # Verify the server.run method was called
         mock_stdio_server.assert_called_once()
         mock_context_manager.__aenter__.assert_called_once()
         assert connection_server.server.run.called
-    
+
     @pytest.mark.asyncio
     @patch("mcp.server.stdio.stdio_server")
     async def test_run_with_exception(self, mock_stdio_server, connection_server):
@@ -1004,29 +1009,29 @@ class TestConnectionServerRun:
         mock_context_manager = AsyncMock()
         mock_context_manager.__aenter__.return_value = [mock_stdin, mock_stdout]
         mock_stdio_server.return_value = mock_context_manager
-        
+
         # Create a patched version of run that catches exceptions the same way the actual run method would
         original_run = connection_server.run
-        
+
         async def patched_run():
             try:
                 await original_run()
             except Exception as e:
                 connection_server.send_log(LOG_LEVEL_ERROR, f"Error in run: {str(e)}")
                 raise
-        
+
         # Replace run with our patched version
         connection_server.run = patched_run
-        
+
         # Mock the server.run method to raise an exception
         connection_server.server.run = AsyncMock(side_effect=ValueError("Test exception"))
-        
+
         # Call the run method and expect an exception
         with pytest.raises(ValueError, match="Test exception"):
             await connection_server.run()
-        
+
         # Verify the server.run method was called and the exception was logged
         mock_stdio_server.assert_called_once()
         mock_context_manager.__aenter__.assert_called_once()
         connection_server.server.run.assert_called_once()
-        connection_server.send_log.assert_called_with(LOG_LEVEL_ERROR, "Error in run: Test exception") 
+        connection_server.send_log.assert_called_with(LOG_LEVEL_ERROR, "Error in run: Test exception")


### PR DESCRIPTION
Adds a new tool called 'dbutils-list-connections' that lists all available database connections defined in the configuration file, including their types and basic information (without sensitive data).

This helps users who have multiple database connections configured to easily see what connections are available before using other tools like list-tables.

The tool:
- Lists all connection names
- Shows database type for each connection
- Displays basic connection info (host, database name, etc.)
- Hides sensitive information (passwords, etc.)
- Optionally checks connection status

Closes #67