### PR TITLE
docs: 添加西班牙语文档支持

### DIFF
--- a/docs/es/configuration.md
+++ b/docs/es/configuration.md
@@ -1,0 +1,358 @@
+# Guía de Configuración
+
+*[English](../en/configuration.md) | [中文](../zh/configuration.md) | [Français](../fr/configuration.md) | Español | [العربية](../ar/examples/README.md) | [Русский](../ru/examples/README.md)*
+
+Este documento proporciona varios ejemplos de configuración para MCP Database Utilities, desde configuraciones básicas hasta escenarios avanzados, ayudándole a configurar y optimizar correctamente sus conexiones de base de datos.
+
+## Configuración Básica
+
+### Configuración Básica de SQLite
+
+SQLite es una base de datos ligera basada en archivos con una configuración muy simple:
+
+```yaml
+connections:
+  my-sqlite:
+    type: sqlite
+    path: /path/to/database.db
+    # Opcional: contraseña de cifrado de la base de datos
+    password: optional_encryption_password
+```
+
+### Configuración Básica de PostgreSQL
+
+Configuración de conexión estándar de PostgreSQL:
+
+```yaml
+connections:
+  my-postgres:
+    type: postgres
+    host: localhost
+    port: 5432
+    dbname: my_database
+    user: postgres_user
+    password: postgres_password
+```
+
+### Configuración Básica de MySQL
+
+Configuración de conexión estándar de MySQL:
+
+```yaml
+connections:
+  my-mysql:
+    type: mysql
+    host: localhost
+    port: 3306
+    database: my_database
+    user: mysql_user
+    password: mysql_password
+    charset: utf8mb4  # Recomendado para soporte completo de Unicode
+```
+
+## Configuración de Múltiples Bases de Datos
+
+Puede definir múltiples conexiones de base de datos en el mismo archivo de configuración:
+
+```yaml
+connections:
+  # Base de datos SQLite de desarrollo
+  dev-db:
+    type: sqlite
+    path: /path/to/dev.db
+
+  # Base de datos PostgreSQL de prueba
+  test-db:
+    type: postgres
+    host: test-postgres.example.com
+    port: 5432
+    dbname: test_db
+    user: test_user
+    password: test_pass
+
+  # Base de datos MySQL de producción
+  prod-db:
+    type: mysql
+    host: prod-mysql.example.com
+    port: 3306
+    database: prod_db
+    user: prod_user
+    password: prod_pass
+    charset: utf8mb4
+```
+
+## Configuración Avanzada
+
+### Configuración de Estilo URL
+
+Además de usar propiedades de configuración estándar, también puede usar URLs de base de datos para configuración parcial. La mejor práctica es poner la estructura de conexión de la base de datos en la URL, pero mantener la información sensible y los parámetros específicos separados:
+
+**Configuración URL de PostgreSQL (Enfoque Recomendado)**:
+
+```yaml
+connections:
+  # Usando URL para PostgreSQL (mejor práctica)
+  postgres-url:
+    type: postgres
+    url: postgresql://host:5432/dbname
+    user: postgres_user
+    password: postgres_password
+    # Otros parámetros configurados aquí
+```
+
+**Configuración URL de MySQL (Enfoque Recomendado)**:
+
+```yaml
+connections:
+  # Usando URL para MySQL (mejor práctica)
+  mysql-url:
+    type: mysql
+    url: mysql://host:3306/dbname
+    user: mysql_user
+    password: mysql_password
+    charset: utf8mb4
+```
+
+**Estilo de Configuración URL Heredado** (no recomendado para producción):
+
+Aunque el siguiente enfoque funciona, no se recomienda para entornos de producción debido al riesgo de errores de análisis de caracteres especiales:
+
+```yaml
+connections:
+  legacy-url:
+    type: postgres
+    url: postgresql://user:password@host:5432/dbname?param1=value1
+    # Nota: No se recomienda incluir credenciales en la URL
+```
+
+**Cuándo Usar URL vs Configuración Estándar**:
+- La configuración URL es adecuada para:
+  - Cuando ya tiene una cadena de conexión de base de datos
+  - Necesita incluir parámetros de conexión específicos en la URL
+  - Migración desde otros sistemas con cadenas de conexión
+- La configuración estándar es adecuada para:
+  - Estructura de configuración más clara
+  - Necesidad de gestionar cada propiedad de configuración por separado
+  - Más fácil de modificar parámetros individuales sin afectar la conexión general
+  - Mejor seguridad y mantenibilidad
+
+En cualquier caso, debe evitar incluir información sensible (como nombres de usuario, contraseñas) en la URL y en su lugar proporcionarlos por separado en los parámetros de configuración.
+
+### Conexiones Seguras SSL/TLS
+
+#### Configuración SSL de PostgreSQL
+
+**Usando Parámetros URL para SSL**:
+
+```yaml
+connections:
+  pg-ssl-url:
+    type: postgres
+    url: postgresql://postgres.example.com:5432/secure_db?sslmode=verify-full&sslcert=/path/to/cert.pem&sslkey=/path/to/key.pem&sslrootcert=/path/to/root.crt
+    user: secure_user
+    password: secure_pass
+```
+
+**Usando Sección de Configuración SSL Dedicada**:
+
+```yaml
+connections:
+  pg-ssl-full:
+    type: postgres
+    host: secure-postgres.example.com
+    port: 5432
+    dbname: secure_db
+    user: secure_user
+    password: secure_pass
+    ssl:
+      mode: verify-full  # Modo de verificación más seguro
+      cert: /path/to/client-cert.pem  # Certificado de cliente
+      key: /path/to/client-key.pem    # Clave privada de cliente
+      root: /path/to/root.crt         # Certificado CA
+```
+
+**Explicación del Modo SSL de PostgreSQL**:
+- `disable`: No se usa SSL en absoluto (no recomendado para producción)
+- `require`: Usar SSL pero no verificar certificado (solo cifrado, sin autenticación)
+- `verify-ca`: Verificar que el certificado del servidor esté firmado por una CA de confianza
+- `verify-full`: Verificar certificado del servidor y coincidencia de nombre de host (opción más segura)
+
+#### Configuración SSL de MySQL
+
+**Usando Parámetros URL para SSL**:
+
+```yaml
+connections:
+  mysql-ssl-url:
+    type: mysql
+    url: mysql://mysql.example.com:3306/secure_db?ssl-mode=verify_identity&ssl-ca=/path/to/ca.pem&ssl-cert=/path/to/client-cert.pem&ssl-key=/path/to/client-key.pem
+    user: secure_user
+    password: secure_pass
+```
+
+**Usando Sección de Configuración SSL Dedicada**:
+
+```yaml
+connections:
+  mysql-ssl-full:
+    type: mysql
+    host: secure-mysql.example.com
+    port: 3306
+    database: secure_db
+    user: secure_user
+    password: secure_pass
+    charset: utf8mb4
+    ssl:
+      mode: verify_identity  # Modo de verificación más seguro
+      ca: /path/to/ca.pem         # Certificado CA
+      cert: /path/to/client-cert.pem  # Certificado de cliente
+      key: /path/to/client-key.pem    # Clave privada de cliente
+```
+
+**Explicación del Modo SSL de MySQL**:
+- `disabled`: No se usa SSL (no recomendado para producción)
+- `preferred`: Usar SSL si está disponible, de lo contrario usar conexión no cifrada
+- `required`: Se debe usar SSL, pero no verificar el certificado del servidor
+- `verify_ca`: Verificar que el certificado del servidor esté firmado por una CA de confianza
+- `verify_identity`: Verificar certificado del servidor y coincidencia de nombre de host (opción más segura)
+
+### Configuración Avanzada de SQLite
+
+**Usando Parámetros URI**:
+
+```yaml
+connections:
+  sqlite-advanced:
+    type: sqlite
+    path: /path/to/db.sqlite?mode=ro&cache=shared&immutable=1
+```
+
+**Parámetros URI Comunes de SQLite**:
+- `mode=ro`: Modo de solo lectura (opción segura)
+- `cache=shared`: Modo de caché compartida, mejora el rendimiento multi-hilo
+- `immutable=1`: Marcar la base de datos como inmutable, mejora el rendimiento
+- `nolock=1`: Deshabilitar el bloqueo de archivos (usar solo cuando esté seguro de que no existen otras conexiones)
+
+## Configuración Especial para Entorno Docker
+
+Cuando se ejecuta en un contenedor Docker, conectarse a bases de datos en el host requiere una configuración especial:
+
+### Conectando a PostgreSQL/MySQL en el Host
+
+**En macOS/Windows**:
+Use el nombre de host especial `host.docker.internal` para acceder al host Docker:
+
+```yaml
+connections:
+  docker-postgres:
+    type: postgres
+    host: host.docker.internal  # Nombre DNS especial que apunta al host Docker
+    port: 5432
+    dbname: my_database
+    user: postgres_user
+    password: postgres_password
+```
+
+**En Linux**:
+Use la IP del puente Docker o use el modo de red host:
+
+```yaml
+connections:
+  docker-mysql:
+    type: mysql
+    host: 172.17.0.1  # IP del puente Docker predeterminada, apunta al host
+    port: 3306
+    database: my_database
+    user: mysql_user
+    password: mysql_password
+```
+
+O use `--network="host"` al iniciar el contenedor Docker, luego use `localhost` como nombre de host.
+
+### Mapeo de SQLite
+
+Para SQLite, necesita mapear el archivo de base de datos en el contenedor:
+
+```bash
+docker run -i --rm \
+  -v /path/to/config.yaml:/app/config.yaml \
+  -v /path/to/database.db:/app/database.db \
+  mcp/dbutils --config /app/config.yaml
+```
+
+Luego apunte a la ruta mapeada en su configuración:
+
+```yaml
+connections:
+  docker-sqlite:
+    type: sqlite
+    path: /app/database.db  # Ruta dentro del contenedor, no la ruta del host
+```
+
+## Escenarios de Configuración Comunes
+
+### Gestión Multi-Entorno
+
+Una buena práctica es usar convenciones de nomenclatura claras para diferentes entornos:
+
+```yaml
+connections:
+  # Entorno de desarrollo
+  dev-postgres:
+    type: postgres
+    host: localhost
+    port: 5432
+    dbname: dev_db
+    user: dev_user
+    password: dev_pass
+
+  # Entorno de prueba
+  test-postgres:
+    type: postgres
+    host: test-server.example.com
+    port: 5432
+    dbname: test_db
+    user: test_user
+    password: test_pass
+
+  # Entorno de producción
+  prod-postgres:
+    type: postgres
+    host: prod-db.example.com
+    port: 5432
+    dbname: prod_db
+    user: prod_user
+    password: prod_pass
+    ssl:
+      mode: verify-full
+      cert: /path/to/cert.pem
+      key: /path/to/key.pem
+      root: /path/to/root.crt
+```
+
+### Configuración Específica para Solo Lectura y Analítica
+
+Para escenarios de análisis de datos, se recomienda usar cuentas de solo lectura y configuración optimizada:
+
+```yaml
+connections:
+  analytics-mysql:
+    type: mysql
+    host: analytics-db.example.com
+    port: 3306
+    database: analytics
+    user: analytics_readonly  # Usar cuenta con permisos de solo lectura
+    password: readonly_pass
+    charset: utf8mb4
+    # Establecer tiempo de espera más largo adecuado para análisis de datos
+```
+
+## Consejos de Solución de Problemas
+
+Si su configuración de conexión no funciona, intente:
+
+1. **Verificar Conexión Básica**: Use el cliente nativo de la base de datos para verificar que la conexión funciona
+2. **Verificar Conectividad de Red**: Asegúrese de que los puertos de red estén abiertos, los firewalls permitan el acceso
+3. **Verificar Credenciales**: Confirme que el nombre de usuario y la contraseña sean correctos
+4. **Problemas de Ruta**: Para SQLite, asegúrese de que la ruta exista y tenga permisos de lectura
+5. **Errores SSL**: Verifique las rutas y permisos de certificados, verifique que los certificados no estén vencidos

--- a/docs/es/examples/README.md
+++ b/docs/es/examples/README.md
@@ -2,11 +2,19 @@
 
 *[English](../../en/installation.md) | [中文](../../zh/installation.md) | [Français](../../fr/installation.md) | Español | [العربية](../../ar/examples/README.md) | [Русский](../../ru/examples/README.md)*
 
-## Próximamente
+## Bienvenido a la Documentación en Español
 
-La documentación en español está en desarrollo y estará disponible pronto.
+Bienvenido a la documentación en español de MCP Database Utilities. Esta documentación le ayudará a utilizar MCP Database Utilities para acceder y analizar sus bases de datos de manera segura con asistentes de IA.
 
-Por ahora, puede consultar la documentación en [inglés](../../en/installation.md) o [francés](../../fr/installation.md).
+## Guías Principales
+
+- [Guía de Instalación](../installation.md) - Instrucciones detalladas para instalar y configurar MCP Database Utilities
+- [Guía de Configuración](../configuration.md) - Ejemplos de configuración y mejores prácticas
+- [Guía de Uso](../usage.md) - Flujo de trabajo básico y escenarios de uso comunes
+
+## Ejemplos por Tipo de Base de Datos
+
+- [Ejemplos de SQLite](sqlite-examples.md) - Ejemplos prácticos para trabajar con bases de datos SQLite
 
 ## Características principales
 

--- a/docs/es/examples/sqlite-examples.md
+++ b/docs/es/examples/sqlite-examples.md
@@ -1,0 +1,150 @@
+# Ejemplos de SQLite
+
+*[English](../../en/examples/sqlite-examples.md) | [中文](../../zh/examples/sqlite-examples.md) | [Français](../../fr/examples/sqlite-examples.md) | Español | [العربية](../../ar/examples/README.md) | [Русский](../../ru/examples/README.md)*
+
+Este documento proporciona ejemplos prácticos para trabajar con bases de datos SQLite usando MCP Database Utilities.
+
+## Configuración Básica
+
+```yaml
+connections:
+  my-sqlite:
+    type: sqlite
+    path: /path/to/database.db
+```
+
+## Operaciones Comunes
+
+### Listar Tablas
+
+**Usted**: "Lista todas las tablas en mi base de datos SQLite."
+
+**IA**: "Aquí están las tablas en su base de datos SQLite:
+- usuarios
+- productos
+- pedidos
+- categorias"
+
+### Ver Estructura de Tabla
+
+**Usted**: "Muéstrame la estructura de la tabla usuarios."
+
+**IA**: "La tabla usuarios tiene la siguiente estructura:
+- id (INTEGER, PRIMARY KEY)
+- username (TEXT, NOT NULL)
+- email (TEXT, NOT NULL, UNIQUE)
+- created_at (TIMESTAMP)
+- last_login (TIMESTAMP)
+- status (TEXT)"
+
+### Consulta Básica
+
+**Usted**: "Muéstrame los 5 principales usuarios por fecha de último inicio de sesión."
+
+**IA**: "Aquí están los 5 principales usuarios por fecha de último inicio de sesión:
+
+| id | username | email | last_login |
+|----|----------|-------|------------|
+| 42 | johndoe | john@example.com | 2023-11-25 14:32:15 |
+| 17 | janedoe | jane@example.com | 2023-11-24 09:45:22 |
+| 31 | bobsmith | bob@example.com | 2023-11-23 18:12:05 |
+| 8 | alicejones | alice@example.com | 2023-11-22 11:30:47 |
+| 53 | mikebrown | mike@example.com | 2023-11-21 16:08:33 |"
+
+## Consultas Avanzadas
+
+### Uniendo Tablas
+
+**Usted**: "Muéstrame los últimos 3 pedidos con información de usuario."
+
+**IA**: "Aquí están los últimos 3 pedidos con información de usuario:
+
+| order_id | order_date | username | email | total_amount |
+|----------|------------|----------|-------|--------------|
+| 1042 | 2023-11-25 | johndoe | john@example.com | $125.99 |
+| 1041 | 2023-11-24 | alicejones | alice@example.com | $89.50 |
+| 1040 | 2023-11-23 | bobsmith | bob@example.com | $212.75 |"
+
+### Funciones de Agregación
+
+**Usted**: "¿Cuál es el monto promedio de pedido por categoría?"
+
+**IA**: "Aquí está el monto promedio de pedido por categoría:
+
+| categoría | monto_promedio |
+|----------|----------------|
+| Electrónica | $245.75 |
+| Ropa | $78.30 |
+| Libros | $32.50 |
+| Hogar y Cocina | $124.90 |
+| Deportes y Aire Libre | $156.25 |"
+
+## Análisis de Rendimiento
+
+### Plan de Ejecución de Consulta
+
+**Usted**: "Explica el plan de ejecución para: SELECT * FROM pedidos WHERE user_id = 42"
+
+**IA**: "Plan de ejecución para la consulta:
+```
+QUERY PLAN
+------------------------------------------------------------
+SEARCH TABLE pedidos USING INDEX idx_user_id (user_id=?)
+```
+
+Esta consulta usa el índice `idx_user_id` para encontrar eficientemente pedidos para user_id 42."
+
+### Estadísticas de Tabla
+
+**Usted**: "Obtén estadísticas para la tabla pedidos."
+
+**IA**: "Estadísticas para la tabla pedidos:
+- Recuento de filas: 1,245
+- Tamaño: 2.3 MB
+- Índices: 3 (clave primaria, idx_user_id, idx_order_date)
+- Longitud promedio de fila: 1.9 KB"
+
+## Trabajando con Características Específicas de SQLite
+
+### Usando FTS (Búsqueda de Texto Completo)
+
+**Usted**: "Busca productos que contengan 'auriculares inalámbricos'."
+
+**IA**: "Aquí están los productos que coinciden con 'auriculares inalámbricos':
+
+| product_id | nombre | descripción | precio |
+|------------|------|-------------|-------|
+| 123 | Auriculares Inalámbricos Premium | Auriculares inalámbricos con cancelación de ruido y 30 horas de batería | $199.99 |
+| 145 | Auriculares Inalámbricos Deportivos | Auriculares inalámbricos resistentes al agua para deportes | $89.99 |
+| 187 | Auriculares Inalámbricos Económicos | Auriculares inalámbricos asequibles con buena calidad de sonido | $49.99 |"
+
+### Usando Funciones JSON
+
+**Usted**: "Muéstrame usuarios con 'premium' en sus preferencias."
+
+**IA**: "Aquí están los usuarios con 'premium' en sus preferencias:
+
+| id | username | preferencias |
+|----|----------|-------------|
+| 42 | johndoe | {\"subscription\": \"premium\", \"theme\": \"dark\"} |
+| 17 | janedoe | {\"subscription\": \"premium\", \"theme\": \"light\"} |
+| 53 | mikebrown | {\"subscription\": \"premium\", \"theme\": \"auto\"} |"
+
+## Solución de Problemas
+
+### Problemas Comunes
+
+1. **Archivo No Encontrado**
+   - Asegúrese de que la ruta a su archivo de base de datos SQLite sea correcta
+   - Verifique los permisos del archivo
+   - Verifique que el archivo exista
+
+2. **Base de Datos Bloqueada**
+   - SQLite permite solo un escritor a la vez
+   - Asegúrese de que ningún otro proceso esté escribiendo en la base de datos
+   - Considere usar el modo WAL para mejor concurrencia
+
+3. **Problemas de Rendimiento**
+   - Agregue índices para columnas consultadas frecuentemente
+   - Use EXPLAIN QUERY PLAN para identificar consultas lentas
+   - Considere usar declaraciones preparadas para consultas repetidas

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -1,0 +1,343 @@
+# Guía de Instalación
+
+*[English](../en/installation.md) | [中文](../zh/installation.md) | [Français](../fr/installation.md) | Español | [العربية](../ar/examples/README.md) | [Русский](../ru/examples/README.md)*
+
+Este documento proporciona pasos simples y fáciles de seguir para instalar y configurar MCP Database Utilities, permitiendo que su asistente de IA acceda y analice sus bases de datos de manera segura.
+
+## ¿Qué es MCP?
+
+MCP (Model Context Protocol) es un protocolo que permite a las aplicaciones de IA (como Claude) utilizar herramientas externas. MCP Database Utilities es una de estas herramientas que permite a la IA leer el contenido de su base de datos sin modificar ningún dato.
+
+## Antes de Comenzar
+
+Antes de iniciar la instalación, asegúrese de tener:
+
+- Una aplicación de IA compatible con MCP (como Claude Desktop, Cursor, etc.)
+- Al menos una base de datos a la que desea que la IA acceda (SQLite, MySQL o PostgreSQL)
+
+## Elija su Método de Instalación
+
+Ofrecemos cuatro métodos de instalación simples. Elija el que mejor funcione para usted:
+
+| Método de Instalación | Mejor Para | Ventajas |
+|---------|---------|------|
+| **Opción A: Usando uvx** | La mayoría de usuarios | Simple y rápido, recomendado |
+| **Opción B: Usando Docker** | Usuarios que prefieren aplicaciones en contenedores | Entorno aislado |
+| **Opción C: Usando Smithery** | Usuarios de Claude Desktop | Instalación con un clic, más fácil |
+| **Opción D: Instalación Offline** | Usuarios en entornos sin internet | No se necesita conexión de red |
+
+## Opción A: Usando uvx (Recomendado)
+
+### Paso 1: Instalar la herramienta uv
+
+**En Mac o Linux**:
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+```
+
+**En Windows**:
+```powershell
+powershell -ExecutionPolicy ByPass -c "irm https://astral.sh/uv/install.ps1 | iex"
+```
+
+Después de la instalación, verifique que funcione escribiendo este comando en su terminal:
+```bash
+uv --version
+```
+Debería ver algo como `uv 0.5.5` en la salida.
+
+### Paso 2: Crear un archivo de configuración de base de datos
+
+1. Cree un archivo llamado `config.yaml` en su computadora
+2. Copie el siguiente contenido en el archivo (elija el que coincida con su tipo de base de datos):
+
+**Ejemplo de Base de Datos SQLite**:
+```yaml
+connections:
+  my_sqlite:
+    type: sqlite
+    path: C:/path/to/your/database.db
+```
+
+**Ejemplo de Base de Datos PostgreSQL**:
+```yaml
+connections:
+  my_postgres:
+    type: postgres
+    host: localhost
+    port: 5432
+    dbname: my_database
+    user: postgres_user
+    password: postgres_password
+```
+
+**Ejemplo de Base de Datos MySQL**:
+```yaml
+connections:
+  my_mysql:
+    type: mysql
+    host: localhost
+    port: 3306
+    database: my_database
+    user: mysql_user
+    password: mysql_password
+```
+
+> Por favor, reemplace la información de ejemplo con los detalles reales de su base de datos. Para más opciones de configuración, consulte la [Guía de Configuración](configuration.md).
+
+### Paso 3: Configurar su aplicación de IA
+
+#### Configuración de Claude Desktop
+
+1. Abra la aplicación Claude Desktop
+2. Haga clic en el ícono de configuración en la parte inferior izquierda
+3. Seleccione "MCP Servers"
+4. Haga clic en "Add Server"
+5. Agregue la siguiente configuración:
+
+```json
+"dbutils": {
+  "command": "uvx",
+  "args": [
+    "mcp-dbutils",
+    "--config",
+    "C:/Users/SuNombreDeUsuario/config.yaml"
+  ]
+}
+```
+
+> Importante: Reemplace `C:/Users/SuNombreDeUsuario/config.yaml` con la ruta real al archivo de configuración que creó en el Paso 2.
+
+#### Configuración de Cursor
+
+1. Abra la aplicación Cursor
+2. Vaya a "Settings" → "MCP"
+3. Haga clic en "Add MCP Server"
+4. Complete la siguiente información:
+   - Name: `Database Utility MCP`
+   - Type: `Command` (predeterminado)
+   - Command: `uvx mcp-dbutils --config C:/Users/SuNombreDeUsuario/config.yaml`
+
+> Importante: Reemplace `C:/Users/SuNombreDeUsuario/config.yaml` con la ruta real al archivo de configuración que creó en el Paso 2.
+
+## Opción B: Usando Docker
+
+### Paso 1: Instalar Docker
+
+Si no tiene Docker instalado, descárguelo e instálelo desde [docker.com](https://www.docker.com/products/docker-desktop/).
+
+### Paso 2: Crear un archivo de configuración de base de datos
+
+Igual que el Paso 2 en la Opción A, cree un archivo `config.yaml`.
+
+### Paso 3: Configurar su aplicación de IA
+
+#### Configuración de Claude Desktop
+
+1. Abra la aplicación Claude Desktop
+2. Haga clic en el ícono de configuración en la parte inferior izquierda
+3. Seleccione "MCP Servers"
+4. Haga clic en "Add Server"
+5. Agregue la siguiente configuración:
+
+```json
+"dbutils": {
+  "command": "docker",
+  "args": [
+    "run",
+    "-i",
+    "--rm",
+    "-v",
+    "C:/Users/SuNombreDeUsuario/config.yaml:/app/config.yaml",
+    "mcp/dbutils",
+    "--config",
+    "/app/config.yaml"
+  ]
+}
+```
+
+> Importante: Reemplace `C:/Users/SuNombreDeUsuario/config.yaml` con la ruta real al archivo de configuración que creó en el Paso 2.
+
+#### Configuración de Cursor
+
+1. Abra la aplicación Cursor
+2. Vaya a "Settings" → "MCP"
+3. Haga clic en "Add MCP Server"
+4. Complete la siguiente información:
+   - Name: `Database Utility MCP`
+   - Type: `Command` (predeterminado)
+   - Command: `docker run -i --rm -v C:/Users/SuNombreDeUsuario/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml`
+
+> Importante: Reemplace `C:/Users/SuNombreDeUsuario/config.yaml` con la ruta real al archivo de configuración que creó en el Paso 2.
+
+## Opción C: Usando Smithery (Un Clic para Claude)
+
+Si usa Claude Desktop, este es el método de instalación más simple:
+
+1. Asegúrese de tener Node.js instalado
+2. Abra una terminal o símbolo del sistema
+3. Ejecute el siguiente comando:
+
+```bash
+npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
+```
+
+4. Siga las instrucciones en pantalla para completar la instalación
+
+Este método maneja automáticamente toda la configuración, por lo que no necesita editar manualmente ningún archivo.
+
+## Opción D: Instalación Offline
+
+Si necesita usar la herramienta en un entorno sin acceso a Internet, o desea usar una versión específica:
+
+### Paso 1: Obtener el código fuente
+
+En un entorno con acceso a Internet:
+1. Descargue el código fuente desde GitHub: `git clone https://github.com/donghao1393/mcp-dbutils.git`
+2. O descargue un archivo zip desde la [página de Releases](https://github.com/donghao1393/mcp-dbutils/releases)
+3. Copie los archivos descargados a su entorno offline
+
+### Paso 2: Crear un archivo de configuración de base de datos
+
+Igual que el Paso 2 en la Opción A, cree un archivo `config.yaml`.
+
+### Paso 3: Configurar su aplicación de IA
+
+#### Configuración de Claude Desktop
+
+1. Abra la aplicación Claude Desktop
+2. Haga clic en el ícono de configuración en la parte inferior izquierda
+3. Seleccione "MCP Servers"
+4. Haga clic en "Add Server"
+5. Agregue la siguiente configuración:
+
+```json
+"dbutils": {
+  "command": "uv",
+  "args": [
+    "--directory",
+    "C:/Users/SuNombreDeUsuario/mcp-dbutils",
+    "run",
+    "mcp-dbutils",
+    "--config",
+    "C:/Users/SuNombreDeUsuario/config.yaml"
+  ]
+}
+```
+
+> Importante: Reemplace las rutas con las rutas reales a su directorio de código fuente y archivo de configuración.
+
+## Verificando su Instalación
+
+Después de completar la instalación, verifiquemos que todo funcione correctamente:
+
+### Probando la Conexión
+
+1. Abra su aplicación de IA (Claude Desktop o Cursor)
+2. Pregunte a su IA: **"¿Puedes verificar si puedes conectarte a mi base de datos?"**
+3. Si está configurado correctamente, la IA responderá que se ha conectado exitosamente a su base de datos
+
+### Pruebe Comandos Simples
+
+Una vez conectado, puede probar estos comandos simples:
+
+- **"Lista todas las tablas en mi base de datos"**
+- **"Describe la estructura de la tabla clientes"**
+- **"Consulta los 5 productos más caros en la tabla productos"**
+
+## Solución de Problemas Comunes
+
+### Problema 1: La IA No Puede Encontrar el Comando uvx
+
+**Síntoma**: La IA responde con "comando uvx no encontrado" o error similar
+
+**Solución**:
+1. Confirme que uv está instalado correctamente: Ejecute `uv --version` en su terminal
+2. Si está instalado pero sigue obteniendo errores, podría ser un problema de variable de entorno:
+   - En Windows, verifique si la variable de entorno PATH incluye el directorio de instalación de uv
+   - En Mac/Linux, podría necesitar reiniciar su terminal o ejecutar `source ~/.bashrc` o `source ~/.zshrc`
+
+### Problema 2: No Puede Conectarse a la Base de Datos
+
+**Síntoma**: La IA informa que no puede conectarse a su base de datos
+
+**Solución**:
+1. **Verifique si su base de datos está ejecutándose**: Asegúrese de que su servidor de base de datos esté iniciado
+2. **Verifique la información de conexión**: Revise cuidadosamente el host, puerto, nombre de usuario y contraseña en su config.yaml
+3. **Verifique la configuración de red**:
+   - Si usa Docker, para bases de datos locales, use `host.docker.internal` como nombre de host
+   - Confirme que los firewalls no estén bloqueando la conexión
+
+### Problema 3: Error de Ruta del Archivo de Configuración
+
+**Síntoma**: La IA informa que no puede encontrar el archivo de configuración
+
+**Solución**:
+1. **Use rutas absolutas**: Asegúrese de usar rutas absolutas completas en la configuración de su aplicación de IA
+2. **Verifique los permisos del archivo**: Asegúrese de que el archivo de configuración sea legible por el usuario actual
+3. **Evite caracteres especiales**: No use caracteres especiales o espacios en la ruta, o use comillas si es necesario
+
+### Problema 4: Problemas de Ruta de Base de Datos SQLite
+
+**Síntoma**: La conexión falla cuando usa SQLite
+
+**Solución**:
+1. **Verifique la ruta del archivo**: Asegúrese de que el archivo de base de datos SQLite exista y la ruta sea correcta
+2. **Verifique los permisos**: Asegúrese de que el archivo de base de datos tenga permisos de lectura
+3. **Al usar Docker**: Asegúrese de haber mapeado correctamente la ruta del archivo SQLite
+
+## Actualizando a la Última Versión
+
+Las actualizaciones regulares proporcionan nuevas características y correcciones de seguridad. Elija el método de actualización que coincida con su método de instalación:
+
+### Actualización de Opción A (uvx)
+
+Cuando ejecuta MCP Database Utilities usando el comando `uvx` (por ejemplo, `uvx mcp-dbutils`), automáticamente usa la última versión sin requerir actualizaciones manuales.
+
+Si está usando el método de instalación tradicional (no el comando `uvx`), puede actualizar manualmente con:
+
+```bash
+uv pip install -U mcp-dbutils
+```
+
+### Actualización de Opción B (Docker)
+
+```bash
+docker pull mcp/dbutils:latest
+```
+
+### Actualización de Opción C (Smithery)
+
+```bash
+npx -y @smithery/cli update @donghao1393/mcp-dbutils
+```
+
+### Actualización de Opción D (Offline)
+
+1. Descargue la última versión del código fuente en un entorno con acceso a Internet
+2. Reemplace los archivos de código fuente en su entorno offline
+
+## Ejemplos de Interacciones
+
+Después de una instalación exitosa, puede probar estas conversaciones de ejemplo:
+
+**Usted**: ¿Puedes listar todas las tablas en mi base de datos?
+
+**IA**: Voy a revisar su base de datos. Aquí están las tablas en su base de datos:
+- clientes
+- productos
+- pedidos
+- inventario
+
+**Usted**: ¿Cómo es la estructura de la tabla clientes?
+
+**IA**: La tabla clientes tiene la siguiente estructura:
+- id (entero, clave primaria)
+- nombre (texto)
+- email (texto)
+- fecha_registro (fecha)
+- ultima_compra (fecha)
+
+**Usted**: ¿Cuántos clientes realizaron compras en el último mes?
+
+**IA**: Déjame ejecutar una consulta para averiguarlo... Según los datos, 28 clientes realizaron compras en el último mes. El valor total de estas compras fue $15,742.50.

--- a/docs/es/usage.md
+++ b/docs/es/usage.md
@@ -1,0 +1,227 @@
+# Guía de Uso
+
+*[English](../en/usage.md) | [中文](../zh/usage.md) | [Français](../fr/usage.md) | Español | [العربية](../ar/examples/README.md) | [Русский](../ru/examples/README.md)*
+
+Este documento proporciona instrucciones detalladas para usar MCP Database Utilities, ayudándole a aprovechar al máximo sus capacidades para el análisis de datos con IA.
+
+## Flujo de Trabajo Básico
+
+El flujo de trabajo básico para usar MCP Database Utilities es el siguiente:
+
+1. **Configurar Conexiones de Base de Datos**: Defina sus conexiones de base de datos en el archivo `config.yaml`
+2. **Iniciar el Servicio MCP**: Lance el servicio a través de la configuración de su cliente de IA
+3. **Interactuar con la IA**: Haga preguntas sobre sus bases de datos usando lenguaje natural
+4. **Ver Resultados**: La IA ejecutará las consultas necesarias y presentará los resultados en un formato fácil de entender
+
+## Herramientas Disponibles
+
+MCP Database Utilities proporciona varias herramientas que su IA puede usar:
+
+### dbutils-list-connections
+
+Lista todas las conexiones de base de datos disponibles definidas en su configuración.
+
+**Ejemplo de Interacción**:
+
+**Usted**: "¿Qué conexiones de base de datos tengo disponibles?"
+
+**IA**: "Verificaré sus conexiones de base de datos disponibles. Esto es lo que encontré:
+
+1. **postgres-db**
+   - Tipo: PostgreSQL
+   - Host: localhost
+   - Base de datos: analytics
+   - Usuario: analyst
+
+2. **sqlite-db**
+   - Tipo: SQLite
+   - Ruta: /path/to/database.db
+
+3. **mysql-db**
+   - Tipo: MySQL
+   - Host: db.example.com
+   - Base de datos: customer_data
+   - Usuario: reader"
+
+### dbutils-list-tables
+
+Lista todas las tablas en la base de datos especificada.
+
+**Ejemplo de Interacción**:
+
+**Usted**: "Lista todas las tablas en mi base de datos postgres."
+
+**IA**: "Verificaré eso para usted. Aquí están las tablas en su base de datos postgres:
+- clientes
+- productos
+- pedidos
+- inventario
+- empleados"
+
+### dbutils-run-query
+
+Ejecuta consultas SQL en la base de datos especificada (solo operaciones SELECT).
+
+**Ejemplo de Interacción**:
+
+**Usted**: "Consulta el número de clientes que se registraron en los últimos 30 días."
+
+**IA**: "Verificaré eso para usted. Según los datos, ha habido 42 nuevos registros de clientes en los últimos 30 días."
+
+### dbutils-get-stats
+
+Obtiene estadísticas sobre una tabla, como recuento de filas, tamaño y estadísticas de columnas.
+
+**Ejemplo de Interacción**:
+
+**Usted**: "Obtén estadísticas para la tabla productos."
+
+**IA**: "Aquí están las estadísticas para la tabla productos:
+- Total de filas: 1,245
+- Tamaño de la tabla: 2.3 MB
+- Estadísticas de columnas:
+  * product_id: 1,245 valores únicos
+  * categoría: 8 categorías distintas
+  * precio: promedio $45.99, mín $5.99, máx $299.99"
+
+### dbutils-list-constraints
+
+Lista las restricciones para una tabla, como claves primarias, claves foráneas, etc.
+
+**Ejemplo de Interacción**:
+
+**Usted**: "Muestra las restricciones para la tabla pedidos."
+
+**IA**: "La tabla pedidos tiene las siguientes restricciones:
+- Clave primaria: order_id
+- Clave foránea: customer_id referencia clientes(id)
+- Clave foránea: product_id referencia productos(id)
+- Restricción de verificación: order_amount > 0"
+
+### dbutils-explain-query
+
+Obtiene el plan de ejecución de la consulta y estimaciones de costo.
+
+**Ejemplo de Interacción**:
+
+**Usted**: "Explica el plan de ejecución para esta consulta: SELECT * FROM pedidos WHERE customer_id = 123"
+
+**IA**: "El plan de ejecución para esta consulta es:
+1. Escaneo de índice: usando el índice customer_id_idx
+2. Costo estimado: 12.5
+3. Filas estimadas: 8
+4. Condición de filtro: customer_id = 123"
+
+### dbutils-get-performance
+
+Obtiene métricas de rendimiento de la base de datos.
+
+**Ejemplo de Interacción**:
+
+**Usted**: "Obtén métricas de rendimiento para la base de datos."
+
+**IA**: "Métricas de rendimiento actuales de la base de datos:
+- Tiempo de ejecución de consulta: 45ms promedio
+- Tasa de aciertos de caché: 87%
+- Conexiones activas: 3
+- Tasa de error reciente: 0.2%"
+
+### dbutils-analyze-query
+
+Analiza el rendimiento de consultas SQL y proporciona sugerencias de optimización.
+
+**Ejemplo de Interacción**:
+
+**Usted**: "Analiza esta consulta: SELECT * FROM pedidos JOIN clientes ON pedidos.customer_id = clientes.id WHERE order_date > '2023-01-01'"
+
+**IA**: "Resultados del análisis de consulta:
+1. Problema de rendimiento: Usar SELECT * recupera columnas innecesarias
+2. Índice faltante: No hay índice en la columna order_date
+3. Sugerencias de optimización:
+   - Seleccione solo las columnas necesarias
+   - Agregue un índice en la columna order_date
+   - Considere agregar una cláusula LIMIT para restringir el recuento de resultados"
+
+## Escenarios de Uso Comunes
+
+### 1. Exploración de Datos
+
+**Usted**: "Quiero entender la estructura de mi base de datos."
+
+**IA**: "Puedo ayudarte a explorar la estructura de tu base de datos. Déjame listar todas las tablas, y luego puedes elegir una para aprender más sobre su estructura."
+
+**Usted**: "Bien, lista todas las tablas."
+
+**IA**: "Tu base de datos contiene las siguientes tablas:
+- clientes
+- productos
+- pedidos
+- inventario
+- empleados
+
+¿Sobre qué tabla te gustaría saber más?"
+
+**Usted**: "Cuéntame sobre la estructura de la tabla clientes."
+
+**IA**: "La tabla clientes tiene la siguiente estructura:
+- id (entero, clave primaria)
+- nombre (varchar(100), no nulo)
+- email (varchar(100), único, no nulo)
+- fecha_registro (fecha, no nulo)
+- ultimo_login (timestamp)
+- estado (enum: 'activo', 'inactivo', 'suspendido')"
+
+### 2. Análisis de Datos
+
+**Usted**: "Analiza las tendencias de ventas durante los últimos 6 meses."
+
+**IA**: "Analizaré las tendencias de ventas durante los últimos 6 meses. Déjame ejecutar algunas consultas..."
+
+[La IA ejecuta múltiples consultas, analizando datos de ventas]
+
+**IA**: "Basado en el análisis de los últimos 6 meses:
+1. Ventas totales: $1,245,678, un aumento del 15% respecto a los 6 meses anteriores
+2. Producto más vendido: Producto X, representando el 23% de las ventas totales
+3. Períodos pico de ventas: viernes y sábados, representando el 45% de las ventas totales
+4. Tasa de retención de clientes: 78%, un aumento del 5% respecto a los 6 meses anteriores"
+
+### 3. Análisis entre Bases de Datos
+
+**Usted**: "Compara la estructura de la tabla usuarios entre las bases de datos de producción y prueba."
+
+**IA**: "Compararé la estructura de la tabla usuarios entre las dos bases de datos..."
+
+[La IA consulta ambas bases de datos para las estructuras de tabla]
+
+**IA**: "Diferencias en la estructura de la tabla usuarios entre las bases de datos de producción y prueba:
+1. Producción tiene una columna adicional 'last_login_ip' (varchar(45))
+2. La columna 'email' de la base de datos de prueba no tiene una restricción única
+3. Producción tiene un índice adicional: idx_user_status
+4. La base de datos de prueba carece de la restricción de clave foránea: fk_user_role"
+
+## Mejores Prácticas
+
+### Optimización de Consultas
+
+1. **Limitar el Tamaño del Conjunto de Resultados**: Use cláusulas LIMIT para restringir el número de filas devueltas
+2. **Seleccionar Solo Columnas Necesarias**: Evite usar SELECT *
+3. **Usar Columnas Indexadas**: Use columnas con índices en cláusulas WHERE
+4. **Evitar Cálculos Complejos**: Mueva cálculos complejos a la capa de aplicación
+
+### Recomendaciones de Seguridad
+
+1. **Usar Cuentas de Solo Lectura**: Cree cuentas de base de datos dedicadas de solo lectura para acceso de IA
+2. **Limitar el Acceso a Tablas**: Otorgue acceso solo a las tablas necesarias
+3. **Usar SSL/TLS**: Habilite el cifrado para conexiones remotas de base de datos
+4. **Rotar Contraseñas Regularmente**: Cambie las contraseñas de la base de datos periódicamente
+
+### Optimización de Rendimiento
+
+1. **Configuración del Pool de Conexiones**: Ajuste el tamaño del pool de conexiones según su uso
+2. **Configuración de Tiempo de Espera de Consulta**: Establezca duraciones razonables de tiempo de espera de consulta
+3. **Caché de Resultados**: Considere el almacenamiento en caché para datos consultados frecuentemente
+4. **Monitorear el Rendimiento**: Verifique regularmente las métricas de rendimiento para identificar posibles problemas
+
+## Solución de Problemas
+
+Si encuentra problemas durante el uso, consulte la sección de solución de problemas en la [Guía de Instalación](installation.md) o consulte la [Documentación Técnica](technical/architecture.md) para obtener información más detallada.

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,7 +7,7 @@ Welcome to the MCP Database Utilities documentation. Please select your preferre
 - [English](en/installation.md)
 - [中文 (Chinese)](zh/installation.md)
 - [Français (French)](fr/installation.md)
-- [Español (Spanish)](es/examples/README.md) - *Coming soon*
+- [Español (Spanish)](es/installation.md)
 - [العربية (Arabic)](ar/examples/README.md) - *Coming soon*
 - [Русский (Russian)](ru/examples/README.md) - *Coming soon*
 


### PR DESCRIPTION
## 描述

为项目文档添加西班牙语支持，继续实施联合国官方语言文档支持计划。

## 实现内容

1. 添加了西班牙语版本的核心文档：
   - 安装指南 (installation.md)
   - 配置指南 (configuration.md)
   - 使用指南 (usage.md)
   - SQLite 示例 (examples/sqlite-examples.md)

2. 更新了语言切换机制：
   - 更新了文档根目录的语言选择页面 (docs/index.md)
   - 确保所有文档都有正确的语言切换链接

## 后续计划

按照联合国官方语言的顺序，继续添加其他语言的支持：
1. 阿拉伯语（下一步）
2. 俄语

关联 #69