### PR TITLE
fix: 修复MySQL和PostgreSQL处理器中变量作用域问题

### DIFF
--- a/src/mcp_dbutils/mysql/handler.py
+++ b/src/mcp_dbutils/mysql/handler.py
@@ -93,6 +93,7 @@ class MySQLHandler(ConnectionHandler):
 
     async def get_schema(self, table_name: str) -> str:
         """Get table schema information"""
+        conn = None
         try:
             conn_params = self.config.get_connection_params()
             conn = mysql.connector.connect(**conn_params)

--- a/src/mcp_dbutils/mysql/handler.py
+++ b/src/mcp_dbutils/mysql/handler.py
@@ -62,6 +62,7 @@ class MySQLHandler(ConnectionHandler):
 
     async def get_tables(self) -> list[types.Resource]:
         """Get all table resources"""
+        conn = None
         try:
             conn_params = self.config.get_connection_params()
             conn = mysql.connector.connect(**conn_params)

--- a/src/mcp_dbutils/postgres/handler.py
+++ b/src/mcp_dbutils/postgres/handler.py
@@ -33,6 +33,7 @@ class PostgreSQLHandler(ConnectionHandler):
 
     async def get_tables(self) -> list[types.Resource]:
         """Get all table resources"""
+        conn = None
         try:
             conn_params = self.config.get_connection_params()
             conn = psycopg2.connect(**conn_params)

--- a/src/mcp_dbutils/postgres/handler.py
+++ b/src/mcp_dbutils/postgres/handler.py
@@ -67,6 +67,7 @@ class PostgreSQLHandler(ConnectionHandler):
 
     async def get_schema(self, table_name: str) -> str:
         """Get table schema information"""
+        conn = None
         try:
             conn_params = self.config.get_connection_params()
             conn = psycopg2.connect(**conn_params)

--- a/tests/unit/test_mysql_handler.py
+++ b/tests/unit/test_mysql_handler.py
@@ -61,17 +61,17 @@ class TestMySQLHandler:
                 {'table_name': 'users', 'description': 'User table'},
                 {'table_name': 'orders', 'description': None}
             ]
-            
+
             # Call the method
             result = await handler.get_tables()
-            
+
             # Verify connection was made with correct parameters
             mock_connect.assert_called_once()
-            
+
             # Verify the cursor was used correctly
             mock_conn.cursor().__enter__().execute.assert_called_once()
             mock_conn.cursor().__enter__().fetchall.assert_called_once()
-            
+
             # Verify the result format
             assert isinstance(result, list)
             assert len(result) == 2
@@ -80,35 +80,21 @@ class TestMySQLHandler:
             assert result[0].description == 'User table'
             assert result[1].name == 'orders schema'
             assert result[1].description is None
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_tables_error(self, handler, mock_conn):
-        """Test error handling when getting tables"""
-        # Save the original method
-        original_get_tables = handler.get_tables
-        
-        # Replace with a method that raises the expected exception
-        async def mock_get_tables():
-            handler.stats.record_error.return_value = None
-            handler.stats.record_error("Error")
-            raise ConnectionHandlerError("Failed to get tables: Connection failed")
-        
-        # Set the mock method
-        handler.get_tables = mock_get_tables
-        
-        try:
+    async def test_get_tables_error(self, handler):
+        """Test error handling when getting tables with connection failure"""
+        # Mock the connector.connect function to raise an exception
+        with patch('mysql.connector.connect', side_effect=mysql.connector.Error('Connection failed')):
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Failed to get tables"):
                 await handler.get_tables()
-            
+
             # Verify error was recorded
             handler.stats.record_error.assert_called_once()
-        finally:
-            # Restore original method
-            handler.get_tables = original_get_tables
 
     @pytest.mark.asyncio
     async def test_get_schema(self, handler, mock_conn):
@@ -123,53 +109,39 @@ class TestMySQLHandler:
             constraints = [
                 {'constraint_name': 'PRIMARY', 'constraint_type': 'PRIMARY KEY'}
             ]
-            
+
             # Set up the mock cursor to return different data for different queries
             mock_cursor = mock_conn.cursor().__enter__()
             mock_cursor.fetchall.side_effect = [columns, constraints]
-            
+
             # Call the method
             result = await handler.get_schema('users')
-            
+
             # Verify connection was made with correct parameters
             mock_connect.assert_called_once()
-            
+
             # Verify the cursor was used correctly for both queries
             assert mock_cursor.execute.call_count == 2
-            
+
             # Verify the result format (it should be a string representation of dict)
             assert isinstance(result, str)
             assert "'columns':" in result
             assert "'constraints':" in result
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
     @pytest.mark.asyncio
-    async def test_get_schema_error(self, handler, mock_conn):
-        """Test error handling when getting schema"""
-        # Save the original method
-        original_get_schema = handler.get_schema
-        
-        # Replace with a method that raises the expected exception
-        async def mock_get_schema(table_name):
-            handler.stats.record_error.return_value = None
-            handler.stats.record_error("Error")
-            raise ConnectionHandlerError("Failed to read table schema: Connection failed")
-        
-        # Set the mock method
-        handler.get_schema = mock_get_schema
-        
-        try:
+    async def test_get_schema_error(self, handler):
+        """Test error handling when getting schema with connection failure"""
+        # Mock the connector.connect function to raise an exception
+        with patch('mysql.connector.connect', side_effect=mysql.connector.Error('Connection failed')):
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Failed to read table schema"):
                 await handler.get_schema('users')
-            
+
             # Verify error was recorded
             handler.stats.record_error.assert_called_once()
-        finally:
-            # Restore original method
-            handler.get_schema = original_get_schema
 
     @pytest.mark.asyncio
     async def test_execute_query(self, handler, mock_conn):
@@ -183,22 +155,22 @@ class TestMySQLHandler:
                 {'id': 1, 'name': 'Test User'},
                 {'id': 2, 'name': 'Another User'}
             ]
-            
+
             # Call the method
             result = await handler._execute_query('SELECT * FROM users')
-            
+
             # Verify connection was made
             mock_connect.assert_called_once()
-            
+
             # Verify the cursor was used correctly
             assert mock_cursor.execute.call_count == 2  # SET TRANSACTION + Query (不再需要ROLLBACK)
             mock_cursor.fetchall.assert_called_once()
-            
+
             # Verify the result format
             assert isinstance(result, str)
             assert "columns" in result
             assert "rows" in result
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -210,11 +182,11 @@ class TestMySQLHandler:
             # Mock cursor to raise an exception when executing the query
             mock_cursor = mock_conn.cursor().__enter__()
             mock_cursor.execute.side_effect = [None, mysql.connector.Error('Query failed'), None]
-            
+
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Query failed"):
                 await handler._execute_query('SELECT * FROM users')
-            
+
             # Verify connection was closed even after an error
             mock_conn.close.assert_called_once()
 
@@ -244,13 +216,13 @@ class TestMySQLHandler:
             ]
             mock_cursor.fetchone.side_effect = [{'count': 1}, table_info]
             mock_cursor.fetchall.return_value = column_info
-            
+
             # Call the method
             result = await handler.get_table_description('users')
-            
+
             # Verify connection was made
             mock_connect.assert_called_once()
-            
+
             # Verify the result format
             assert isinstance(result, str)
             assert "Table: users" in result
@@ -258,7 +230,7 @@ class TestMySQLHandler:
             assert "id" in result
             assert "name" in result
             assert "varchar" in result
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -270,7 +242,7 @@ class TestMySQLHandler:
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Failed to get table description"):
                 await handler.get_table_description('users')
-            
+
             # Verify error was recorded
             handler.stats.record_error.assert_called_once()
 
@@ -284,20 +256,20 @@ class TestMySQLHandler:
             mock_cursor.fetchone.return_value = {
                 'Create Table': 'CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255))'
             }
-            
+
             # Call the method
             result = await handler.get_table_ddl('users')
-            
+
             # Verify connection was made
             mock_connect.assert_called_once()
-            
+
             # Verify the cursor was used correctly
             mock_cursor.execute.assert_called_once_with('SHOW CREATE TABLE users')
             mock_cursor.fetchone.assert_called_once()
-            
+
             # Verify the result format
             assert result == 'CREATE TABLE users (id INT PRIMARY KEY, name VARCHAR(255))'
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -309,13 +281,13 @@ class TestMySQLHandler:
             # Mock cursor to return no DDL
             mock_cursor = mock_conn.cursor().__enter__()
             mock_cursor.fetchone.return_value = None
-            
+
             # Call the method
             result = await handler.get_table_ddl('users')
-            
+
             # Verify the result format
             assert result == 'Failed to get DDL for table users'
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -327,7 +299,7 @@ class TestMySQLHandler:
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Failed to get table DDL"):
                 await handler.get_table_ddl('users')
-            
+
             # Verify error was recorded
             handler.stats.record_error.assert_called_once()
 
@@ -353,28 +325,28 @@ class TestMySQLHandler:
                     'index_comment': 'Name index'
                 }
             ]
-            
+
             mock_cursor = mock_conn.cursor().__enter__()
             # 首先模拟表存在性检查
             mock_cursor.fetchone.side_effect = [{'count': 1}]
             mock_cursor.fetchall.return_value = indexes
-            
+
             # Call the method
             result = await handler.get_table_indexes('users')
-            
+
             # Verify connection was made
             mock_connect.assert_called_once()
-            
+
             # Verify the cursor was used correctly
             assert mock_cursor.execute.call_count == 2  # 表存在性检查 + 索引查询
-            
+
             # Verify the result format
             assert isinstance(result, str)
             assert "Index: PRIMARY" in result
             assert "Type: UNIQUE" in result
             assert "Method: BTREE" in result
             assert "Columns:" in result
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -388,13 +360,13 @@ class TestMySQLHandler:
             # 首先模拟表存在性检查返回成功
             mock_cursor.fetchone.side_effect = [{'count': 1}]
             mock_cursor.fetchall.return_value = []
-            
+
             # Call the method
             result = await handler.get_table_indexes('users')
-            
+
             # Verify the result format
             assert result == "No indexes found on table users"
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -406,7 +378,7 @@ class TestMySQLHandler:
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Failed to get index information"):
                 await handler.get_table_indexes('users')
-            
+
             # Verify error was recorded
             handler.stats.record_error.assert_called_once()
 
@@ -427,29 +399,29 @@ class TestMySQLHandler:
                 {'column_name': 'id', 'data_type': 'int', 'column_type': 'int(11)'},
                 {'column_name': 'name', 'data_type': 'varchar', 'column_type': 'varchar(255)'}
             ]
-            
+
             # Set up the mock cursor to return different data for different queries
             mock_cursor = mock_conn.cursor().__enter__()
             # 首先模拟表存在性检查返回成功
             mock_cursor.fetchone.side_effect = [{'count': 1}, table_stats]
             mock_cursor.fetchall.return_value = columns
-            
+
             # Call the method
             result = await handler.get_table_stats('users')
-            
+
             # Verify connection was made
             mock_connect.assert_called_once()
-            
+
             # Verify the cursor was used correctly
             assert mock_cursor.execute.call_count == 3  # 表存在性检查 + 表统计查询 + 列信息查询
-            
+
             # Verify the result format
             assert isinstance(result, str)
             assert "Table Statistics for users:" in result
             assert "Estimated Row Count: 1,000" in result
             assert "Data Length: 100,000" in result
             assert "Average Row Length: 100" in result
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -462,13 +434,13 @@ class TestMySQLHandler:
             mock_cursor = mock_conn.cursor().__enter__()
             # 首先模拟表存在性检查返回成功，但表统计查询返回空
             mock_cursor.fetchone.side_effect = [{'count': 1}, None]
-            
+
             # Call the method
             result = await handler.get_table_stats('users')
-            
+
             # Verify the result format
             assert result == 'No statistics found for table users'
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -480,7 +452,7 @@ class TestMySQLHandler:
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Failed to get table statistics"):
                 await handler.get_table_stats('users')
-            
+
             # Verify error was recorded
             handler.stats.record_error.assert_called_once()
 
@@ -506,21 +478,21 @@ class TestMySQLHandler:
                     'referenced_column_name': 'id'
                 }
             ]
-            
+
             mock_cursor = mock_conn.cursor().__enter__()
             # 首先模拟表存在性检查返回成功
             mock_cursor.fetchone.side_effect = [{'count': 1}]
             mock_cursor.fetchall.return_value = constraints
-            
+
             # Call the method
             result = await handler.get_table_constraints('users')
-            
+
             # Verify connection was made
             mock_connect.assert_called_once()
-            
+
             # Verify the cursor was used correctly
             assert mock_cursor.execute.call_count == 2  # 表存在性检查 + 约束查询
-            
+
             # Verify the result format
             assert isinstance(result, str)
             assert "Constraints for users:" in result
@@ -528,7 +500,7 @@ class TestMySQLHandler:
             assert "FOREIGN KEY" in result
             assert "fk_order" in result
             assert "orders.id" in result
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -542,13 +514,13 @@ class TestMySQLHandler:
             # 首先模拟表存在性检查返回成功
             mock_cursor.fetchone.side_effect = [{'count': 1}]
             mock_cursor.fetchall.return_value = []
-            
+
             # Call the method
             result = await handler.get_table_constraints('users')
-            
+
             # Verify the result format
             assert result == 'No constraints found on table users'
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -560,7 +532,7 @@ class TestMySQLHandler:
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Failed to get constraint information"):
                 await handler.get_table_constraints('users')
-            
+
             # Verify error was recorded
             handler.stats.record_error.assert_called_once()
 
@@ -572,22 +544,22 @@ class TestMySQLHandler:
             # Mock cursor to return explain results
             explain_result = [{'EXPLAIN': 'Table scan on users'}]
             analyze_result = [{'EXPLAIN': 'Table scan on users (actual time=0.1..0.2 rows=100)'}]
-            
+
             # Set up the mock cursor to return different data for different queries
             mock_cursor = mock_conn.cursor().__enter__()
             mock_cursor.fetchall.side_effect = [explain_result, analyze_result]
-            
+
             # Call the method
             result = await handler.explain_query('SELECT * FROM users')
-            
+
             # Verify connection was made
             mock_connect.assert_called_once()
-            
+
             # Verify the cursor was used correctly
             assert mock_cursor.execute.call_count == 2
             mock_cursor.execute.assert_any_call('EXPLAIN FORMAT=TREE SELECT * FROM users')
             mock_cursor.execute.assert_any_call('EXPLAIN ANALYZE SELECT * FROM users')
-            
+
             # Verify the result format
             assert isinstance(result, str)
             assert "Query Execution Plan:" in result
@@ -595,7 +567,7 @@ class TestMySQLHandler:
             assert "Table scan on users" in result
             assert "Actual Plan (ANALYZE):" in result
             assert "Table scan on users (actual time=0.1..0.2 rows=100)" in result
-            
+
             # Verify connection was closed
             mock_conn.close.assert_called_once()
 
@@ -607,7 +579,7 @@ class TestMySQLHandler:
             # Call the method and expect an exception
             with pytest.raises(ConnectionHandlerError, match="Failed to explain query"):
                 await handler.explain_query('SELECT * FROM users')
-            
+
             # Verify error was recorded
             handler.stats.record_error.assert_called_once()
 
@@ -616,9 +588,134 @@ class TestMySQLHandler:
         """Test cleanup method"""
         # Mock the handler.stats.to_dict method
         handler.stats.to_dict.return_value = {'queries': 10, 'errors': 0}
-        
+
         # Call the method
         await handler.cleanup()
-        
+
         # Verify log was called
-        handler.log.assert_called_once_with('info', 'Final MySQL handler stats: {\'queries\': 10, \'errors\': 0}') 
+        handler.log.assert_called_once_with('info', 'Final MySQL handler stats: {\'queries\': 10, \'errors\': 0}')
+
+    @pytest.mark.asyncio
+    async def test_special_character_password(self):
+        """Test handling of special characters in password"""
+        # Create a handler with a password containing special characters
+        with patch('os.path.exists', return_value=True), \
+             patch('builtins.open', MagicMock()), \
+             patch('yaml.safe_load', return_value={
+                 'connections': {
+                     'test_mysql': {
+                         'type': 'mysql',
+                         'host': 'localhost',
+                         'port': 3306,
+                         'user': 'testuser',
+                         'password': 'test?pass!@#$%^&*()',  # Password with special characters
+                         'database': 'testdb'
+                     }
+                 }
+             }):
+            special_handler = MySQLHandler('config.yaml', 'test_mysql')
+            special_handler.log = MagicMock()
+            special_handler.stats = MagicMock()
+
+            # Mock successful connection
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.__enter__.return_value = mock_cursor
+            mock_cursor.fetchall.return_value = [
+                {'table_name': 'users', 'description': 'User table'}
+            ]
+            mock_conn.cursor.return_value = mock_cursor
+
+            with patch('mysql.connector.connect', return_value=mock_conn) as mock_connect:
+                # Test get_tables method
+                result = await special_handler.get_tables()
+
+                # Verify connection was made with correct parameters including special character password
+                mock_connect.assert_called_once()
+                call_args = mock_connect.call_args[1]
+                assert 'password' in call_args
+                assert call_args['password'] == 'test?pass!@#$%^&*()'
+
+                # Verify the result
+                assert len(result) == 1
+                assert result[0].name == 'users schema'
+
+                # Verify connection was closed
+                mock_conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_special_character_password_connection_error(self):
+        """Test error handling with special characters in password"""
+        # Create a handler with a password containing special characters
+        with patch('os.path.exists', return_value=True), \
+             patch('builtins.open', MagicMock()), \
+             patch('yaml.safe_load', return_value={
+                 'connections': {
+                     'test_mysql': {
+                         'type': 'mysql',
+                         'host': 'localhost',
+                         'port': 3306,
+                         'user': 'testuser',
+                         'password': 'test?pass!@#$%^&*()',  # Password with special characters
+                         'database': 'testdb'
+                     }
+                 }
+             }):
+            special_handler = MySQLHandler('config.yaml', 'test_mysql')
+            special_handler.log = MagicMock()
+            special_handler.stats = MagicMock()
+
+            # Mock connection failure
+            with patch('mysql.connector.connect', side_effect=mysql.connector.Error('Connection failed')):
+                # Test get_tables method with connection failure
+                with pytest.raises(ConnectionHandlerError, match="Failed to get tables"):
+                    await special_handler.get_tables()
+
+                # Verify error was recorded
+                special_handler.stats.record_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_variable_scope_handling(self):
+        """Test proper handling of variable scope in connection methods"""
+        # Create a handler
+        with patch('os.path.exists', return_value=True), \
+             patch('builtins.open', MagicMock()), \
+             patch('yaml.safe_load', return_value={
+                 'connections': {
+                     'test_mysql': {
+                         'type': 'mysql',
+                         'host': 'localhost',
+                         'port': 3306,
+                         'user': 'testuser',
+                         'password': 'testpass',
+                         'database': 'testdb'
+                     }
+                 }
+             }):
+            handler = MySQLHandler('config.yaml', 'test_mysql')
+            handler.log = MagicMock()
+            handler.stats = MagicMock()
+
+            # Test all methods that use connection handling with try/finally blocks
+            methods_to_test = [
+                ('get_tables', []),
+                ('get_schema', ['users']),
+                ('get_table_description', ['users']),
+                ('get_table_ddl', ['users']),
+                ('get_table_indexes', ['users']),
+                ('get_table_stats', ['users']),
+                ('get_table_constraints', ['users']),
+                ('explain_query', ['SELECT * FROM users'])
+            ]
+
+            for method_name, args in methods_to_test:
+                # Mock connection failure
+                with patch('mysql.connector.connect', side_effect=mysql.connector.Error('Connection failed')):
+                    method = getattr(handler, method_name)
+
+                    # Call the method and expect an exception
+                    with pytest.raises(ConnectionHandlerError):
+                        await method(*args)
+
+                    # Verify error was recorded
+                    handler.stats.record_error.assert_called()

--- a/tests/unit/test_postgres_handler.py
+++ b/tests/unit/test_postgres_handler.py
@@ -1,0 +1,268 @@
+"""Unit tests for PostgreSQL connection handler"""
+
+from unittest.mock import MagicMock, patch
+
+import psycopg2
+import pytest
+
+from mcp_dbutils.base import ConnectionHandlerError
+from mcp_dbutils.postgres.handler import PostgreSQLHandler
+
+
+class TestPostgreSQLHandler:
+    """Test PostgreSQL handler functionality with mocks"""
+
+    @pytest.fixture
+    def mock_cursor(self):
+        """Create a mock cursor for PostgreSQL"""
+        cursor = MagicMock()
+        cursor.__enter__.return_value = cursor
+        cursor.fetchall.return_value = []
+        cursor.fetchone.return_value = {}
+        return cursor
+
+    @pytest.fixture
+    def mock_conn(self, mock_cursor):
+        """Create a mock connection for PostgreSQL"""
+        conn = MagicMock()
+        conn.cursor.return_value = mock_cursor
+        return conn
+
+    @pytest.fixture
+    def handler(self):
+        """Create a PostgreSQL handler with mocks"""
+        with patch('os.path.exists', return_value=True), \
+             patch('builtins.open', MagicMock()), \
+             patch('yaml.safe_load', return_value={
+                 'connections': {
+                     'test_postgres': {
+                         'type': 'postgres',
+                         'host': 'localhost',
+                         'port': 5432,
+                         'user': 'testuser',
+                         'password': 'testpass',
+                         'dbname': 'testdb'
+                     }
+                 }
+             }):
+            handler = PostgreSQLHandler('config.yaml', 'test_postgres')
+            handler.log = MagicMock()
+            handler.stats = MagicMock()
+            return handler
+
+    @pytest.mark.asyncio
+    async def test_get_tables(self, handler, mock_conn):
+        """Test getting tables from PostgreSQL"""
+        # Mock the psycopg2.connect function
+        with patch('psycopg2.connect', return_value=mock_conn) as mock_connect:
+            # Mock cursor to return some tables
+            mock_conn.cursor().__enter__().fetchall.return_value = [
+                ('users', 'User table'),
+                ('orders', None)
+            ]
+            
+            # Call the method
+            result = await handler.get_tables()
+            
+            # Verify connection was made with correct parameters
+            mock_connect.assert_called_once()
+            
+            # Verify the cursor was used correctly
+            mock_conn.cursor().__enter__().execute.assert_called_once()
+            mock_conn.cursor().__enter__().fetchall.assert_called_once()
+            
+            # Verify the result format
+            assert isinstance(result, list)
+            assert len(result) == 2
+            assert result[0].name == 'users schema'
+            assert str(result[0].uri) == 'postgres://test_postgres/users/schema'
+            assert result[0].description == 'User table'
+            assert result[1].name == 'orders schema'
+            assert result[1].description is None
+            
+            # Verify connection was closed
+            mock_conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_tables_error(self, handler):
+        """Test error handling when getting tables with connection failure"""
+        # Mock the psycopg2.connect function to raise an exception
+        with patch('psycopg2.connect', side_effect=psycopg2.Error('Connection failed')):
+            # Call the method and expect an exception
+            with pytest.raises(ConnectionHandlerError, match="Failed to get constraint information"):
+                await handler.get_tables()
+            
+            # Verify error was recorded
+            handler.stats.record_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_schema(self, handler, mock_conn):
+        """Test getting schema for a table"""
+        # Mock the psycopg2.connect function
+        with patch('psycopg2.connect', return_value=mock_conn) as mock_connect:
+            # Mock cursor to return columns and constraints
+            columns = [
+                ('id', 'integer', 'NO', 'Primary key'),
+                ('name', 'varchar', 'YES', 'User name')
+            ]
+            constraints = [
+                ('pk_users', 'p')
+            ]
+            
+            # Set up the mock cursor to return different data for different queries
+            mock_cursor = mock_conn.cursor().__enter__()
+            mock_cursor.fetchall.side_effect = [columns, constraints]
+            
+            # Call the method
+            result = await handler.get_schema('users')
+            
+            # Verify connection was made with correct parameters
+            mock_connect.assert_called_once()
+            
+            # Verify the cursor was used correctly for both queries
+            assert mock_cursor.execute.call_count == 2
+            
+            # Verify the result format (it should be a string representation of dict)
+            assert isinstance(result, str)
+            assert "'columns':" in result
+            assert "'constraints':" in result
+            
+            # Verify connection was closed
+            mock_conn.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_schema_error(self, handler):
+        """Test error handling when getting schema with connection failure"""
+        # Mock the psycopg2.connect function to raise an exception
+        with patch('psycopg2.connect', side_effect=psycopg2.Error('Connection failed')):
+            # Call the method and expect an exception
+            with pytest.raises(ConnectionHandlerError, match="Failed to read table schema"):
+                await handler.get_schema('users')
+            
+            # Verify error was recorded
+            handler.stats.record_error.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_special_character_password(self):
+        """Test handling of special characters in password"""
+        # Create a handler with a password containing special characters
+        with patch('os.path.exists', return_value=True), \
+             patch('builtins.open', MagicMock()), \
+             patch('yaml.safe_load', return_value={
+                 'connections': {
+                     'test_postgres': {
+                         'type': 'postgres',
+                         'host': 'localhost',
+                         'port': 5432,
+                         'user': 'testuser',
+                         'password': 'test?pass!@#$%^&*()',  # Password with special characters
+                         'dbname': 'testdb'
+                     }
+                 }
+             }):
+            special_handler = PostgreSQLHandler('config.yaml', 'test_postgres')
+            special_handler.log = MagicMock()
+            special_handler.stats = MagicMock()
+            
+            # Mock successful connection
+            mock_conn = MagicMock()
+            mock_cursor = MagicMock()
+            mock_cursor.__enter__.return_value = mock_cursor
+            mock_cursor.fetchall.return_value = [
+                ('users', 'User table')
+            ]
+            mock_conn.cursor.return_value = mock_cursor
+            
+            with patch('psycopg2.connect', return_value=mock_conn) as mock_connect:
+                # Test get_tables method
+                result = await special_handler.get_tables()
+                
+                # Verify connection was made with correct parameters including special character password
+                mock_connect.assert_called_once()
+                call_args = mock_connect.call_args[1]
+                assert 'password' in call_args
+                assert call_args['password'] == 'test?pass!@#$%^&*()'
+                
+                # Verify the result
+                assert len(result) == 1
+                assert result[0].name == 'users schema'
+                
+                # Verify connection was closed
+                mock_conn.close.assert_called_once()
+                
+    @pytest.mark.asyncio
+    async def test_special_character_password_connection_error(self):
+        """Test error handling with special characters in password"""
+        # Create a handler with a password containing special characters
+        with patch('os.path.exists', return_value=True), \
+             patch('builtins.open', MagicMock()), \
+             patch('yaml.safe_load', return_value={
+                 'connections': {
+                     'test_postgres': {
+                         'type': 'postgres',
+                         'host': 'localhost',
+                         'port': 5432,
+                         'user': 'testuser',
+                         'password': 'test?pass!@#$%^&*()',  # Password with special characters
+                         'dbname': 'testdb'
+                     }
+                 }
+             }):
+            special_handler = PostgreSQLHandler('config.yaml', 'test_postgres')
+            special_handler.log = MagicMock()
+            special_handler.stats = MagicMock()
+            
+            # Mock connection failure
+            with patch('psycopg2.connect', side_effect=psycopg2.Error('Connection failed')):
+                # Test get_tables method with connection failure
+                with pytest.raises(ConnectionHandlerError, match="Failed to get constraint information"):
+                    await special_handler.get_tables()
+                
+                # Verify error was recorded
+                special_handler.stats.record_error.assert_called_once()
+                
+    @pytest.mark.asyncio
+    async def test_variable_scope_handling(self):
+        """Test proper handling of variable scope in connection methods"""
+        # Create a handler
+        with patch('os.path.exists', return_value=True), \
+             patch('builtins.open', MagicMock()), \
+             patch('yaml.safe_load', return_value={
+                 'connections': {
+                     'test_postgres': {
+                         'type': 'postgres',
+                         'host': 'localhost',
+                         'port': 5432,
+                         'user': 'testuser',
+                         'password': 'testpass',
+                         'dbname': 'testdb'
+                     }
+                 }
+             }):
+            handler = PostgreSQLHandler('config.yaml', 'test_postgres')
+            handler.log = MagicMock()
+            handler.stats = MagicMock()
+            
+            # Test all methods that use connection handling with try/finally blocks
+            methods_to_test = [
+                ('get_tables', []),
+                ('get_schema', ['users']),
+                ('get_table_description', ['users']),
+                ('get_table_ddl', ['users']),
+                ('get_table_indexes', ['users']),
+                ('get_table_stats', ['users']),
+                ('get_table_constraints', ['users']),
+                ('explain_query', ['SELECT * FROM users'])
+            ]
+            
+            for method_name, args in methods_to_test:
+                # Mock connection failure
+                with patch('psycopg2.connect', side_effect=psycopg2.Error('Connection failed')):
+                    method = getattr(handler, method_name)
+                    
+                    # Call the method and expect an exception
+                    with pytest.raises(ConnectionHandlerError):
+                        await method(*args)
+                    
+                    # Verify error was recorded
+                    handler.stats.record_error.assert_called()


### PR DESCRIPTION
## 问题描述

在MySQL和PostgreSQL处理器的get_tables和get_schema方法中，conn变量没有初始化为None，导致在连接失败时，finally块中的if conn:检查会尝试访问一个未定义的变量，从而引发UnboundLocalError: cannot access local variable "conn" where it is not associated with a value错误。

这个问题在使用包含特殊字符（如问号）的密码时特别容易触发，因为这可能导致连接失败。

## 解决方案

1. 在get_tables和get_schema方法开始时初始化conn = None，与其他方法保持一致
2. 改进测试用例，确保能够测试到变量作用域问题
   - 修改现有的错误处理测试：将替换整个方法的测试改为模拟连接函数抛出异常的方式
   - 添加特殊字符密码测试：专门测试包含特殊字符（如问号）的密码情况
   - 添加变量作用域测试：测试所有使用try/finally块的方法，确保它们正确处理变量作用域
   - 新增PostgreSQL处理器的单元测试：参考MySQL处理器的测试，确保两者一致

## 相关Issue

Fixes #75