### PR TITLE
fix: 移除不兼容的read_timeout_seconds参数

### DIFF
--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -3,7 +3,7 @@
 import json
 from abc import ABC, abstractmethod
 from contextlib import asynccontextmanager
-from datetime import datetime, timedelta
+from datetime import datetime
 from importlib.metadata import metadata
 from typing import Any, AsyncContextManager, Dict
 
@@ -1037,6 +1037,5 @@ class ConnectionServer:
             await self.server.run(
                 streams[0],
                 streams[1],
-                self.server.create_initialization_options(),
-                read_timeout_seconds=timedelta(seconds=30)  # 设置30秒超时
+                self.server.create_initialization_options()
             )


### PR DESCRIPTION
在升级MCP SDK到v1.7.1后，发现服务无法启动，错误信息为：TypeError: Server.run() got an unexpected keyword argument "read_timeout_seconds"。这是因为新版本的MCP SDK中，Server.run()方法不再接受read_timeout_seconds参数。本PR移除了这个参数，使服务能够正常启动。