### PR TITLE
fix: 修复_extract_table_name方法处理多行SQL语句的问题

### DIFF
--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -569,6 +569,7 @@ class ConnectionServer:
         """Extract table name from SQL statement
 
         This is a simple implementation that works for basic SQL statements.
+        Handles multi-line SQL statements by normalizing whitespace.
 
         Args:
             sql: SQL statement
@@ -577,23 +578,26 @@ class ConnectionServer:
             str: Table name
         """
         sql_type = self._get_sql_type(sql)
-        sql = sql.strip()
+
+        # 预处理SQL：规范化空白字符，将多行SQL转换为单行
+        # 将所有连续的空白字符（包括换行符、制表符等）替换为单个空格
+        normalized_sql = " ".join(sql.split())
 
         if sql_type == "INSERT":
             # INSERT INTO table_name ...
-            match = sql.upper().split("INTO", 1)
+            match = normalized_sql.upper().split("INTO", 1)
             if len(match) > 1:
                 table_part = match[1].strip().split(" ", 1)[0]
                 return table_part.strip('`"[]')
         elif sql_type == "UPDATE":
             # UPDATE table_name ...
-            match = sql.upper().split("UPDATE", 1)
+            match = normalized_sql.upper().split("UPDATE", 1)
             if len(match) > 1:
                 table_part = match[1].strip().split(" ", 1)[0]
                 return table_part.strip('`"[]')
         elif sql_type == "DELETE":
             # DELETE FROM table_name ...
-            match = sql.upper().split("FROM", 1)
+            match = normalized_sql.upper().split("FROM", 1)
             if len(match) > 1:
                 table_part = match[1].strip().split(" ", 1)[0]
                 return table_part.strip('`"[]')

--- a/tests/unit/test_sql_parsing.py
+++ b/tests/unit/test_sql_parsing.py
@@ -86,48 +86,43 @@ class TestSQLParsing:
         assert server._extract_table_name("INSERT INTO users (id, name) VALUES (1, 'test')").lower() == "users"
 
         # Test INSERT with multiple rows
-        # 注意：当前实现在处理多行SQL语句时可能有问题，暂时跳过这个测试
-        # assert server._extract_table_name("""
-        # INSERT INTO users (id, name) VALUES
-        # (1, 'test1'),
-        # (2, 'test2'),
-        # (3, 'test3')
-        # """).lower() == "users"
+        assert server._extract_table_name("""
+        INSERT INTO users (id, name) VALUES
+        (1, 'test1'),
+        (2, 'test2'),
+        (3, 'test3')
+        """).lower() == "users"
 
         # Test INSERT ... SELECT
-        # 注意：当前实现在处理多行SQL语句时可能有问题，暂时跳过这个测试
-        # assert server._extract_table_name("""
-        # INSERT INTO users (id, name, email)
-        # SELECT id, name, email
-        # FROM temp_users
-        # WHERE active = 1
-        # """).lower() == "users"
+        assert server._extract_table_name("""
+        INSERT INTO users (id, name, email)
+        SELECT id, name, email
+        FROM temp_users
+        WHERE active = 1
+        """).lower() == "users"
 
         # Test UPDATE with multiple columns
-        # 注意：当前实现在处理多行SQL语句时可能有问题，暂时跳过这个测试
-        # assert server._extract_table_name("""
-        # UPDATE users
-        # SET name = 'test',
-        #     email = 'test@example.com',
-        #     updated_at = CURRENT_TIMESTAMP
-        # WHERE id IN (1, 2, 3)
-        # """).lower() == "users"
+        assert server._extract_table_name("""
+        UPDATE users
+        SET name = 'test',
+            email = 'test@example.com',
+            updated_at = CURRENT_TIMESTAMP
+        WHERE id IN (1, 2, 3)
+        """).lower() == "users"
 
         # Test DELETE with subquery
-        # 注意：当前实现在处理多行SQL语句时可能有问题，暂时跳过这个测试
-        # assert server._extract_table_name("""
-        # DELETE FROM users
-        # WHERE id IN (
-        #     SELECT user_id
-        #     FROM inactive_users
-        #     WHERE last_login < '2020-01-01'
-        # )
-        # """).lower() == "users"
+        assert server._extract_table_name("""
+        DELETE FROM users
+        WHERE id IN (
+            SELECT user_id
+            FROM inactive_users
+            WHERE last_login < '2020-01-01'
+        )
+        """).lower() == "users"
 
         # Test with comments and whitespace
         assert server._extract_table_name("INSERT INTO users -- comment\nVALUES (1, 'test')").lower() == "users"
-        # 注意：当前实现在处理带换行符的SQL语句时可能有问题，暂时跳过这个测试
-        # assert server._extract_table_name("INSERT INTO\nusers\nVALUES (1, 'test')").lower() == "users"
+        assert server._extract_table_name("INSERT INTO\nusers\nVALUES (1, 'test')").lower() == "users"
         assert server._extract_table_name("UPDATE users -- comment\nSET name = 'test'").lower() == "users"
         assert server._extract_table_name("DELETE FROM users -- comment\nWHERE id = 1").lower() == "users"
 

--- a/tests/unit/test_table_name_handling.py
+++ b/tests/unit/test_table_name_handling.py
@@ -135,18 +135,16 @@ class TestTableNameHandling:
 
             # 测试带空格和注释的SQL
             assert server._extract_table_name("INSERT INTO users -- comment\nVALUES (1, 'test')") == "USERS"
-            # 注意：当前实现在处理带换行符的SQL语句时可能有问题，暂时跳过这个测试
-            # assert server._extract_table_name("INSERT INTO\nusers\nVALUES (1, 'test')") == "USERS"
+            assert server._extract_table_name("INSERT INTO\nusers\nVALUES (1, 'test')") == "USERS"
 
             # 测试复杂SQL
-            # 注意：当前实现在处理多行SQL语句时可能有问题，暂时跳过这个测试
-            # complex_sql = """
-            # INSERT INTO users (id, name, email)
-            # SELECT id, name, email
-            # FROM temp_users
-            # WHERE active = 1
-            # """
-            # assert server._extract_table_name(complex_sql) == "USERS"
+            complex_sql = """
+            INSERT INTO users (id, name, email)
+            SELECT id, name, email
+            FROM temp_users
+            WHERE active = 1
+            """
+            assert server._extract_table_name(complex_sql) == "USERS"
 
             # 测试无效SQL
             assert server._extract_table_name("SELECT * FROM users") == "unknown_table"


### PR DESCRIPTION
## 问题描述

在测试过程中发现，方法在处理多行SQL语句时存在问题。当SQL语句包含换行符时，该方法可能会返回不正确的表名。

## 解决方案

1. 改进方法，使用将多行SQL转换为单行
2. 取消注释之前被注释掉的测试用例
3. 所有测试都通过

## 实现细节

修改了方法，在处理SQL语句之前，先使用将多行SQL转换为单行，这样可以正确处理包含换行符的SQL语句。

## 测试结果

所有测试都通过，包括之前被注释掉的测试用例。

## 相关Issue

修复了Issue #97中提到的问题。

Fixes #97