### PR TITLE
feat: 实现MongoDB适配器

### DIFF
--- a/src/mcp_dbutils/base.py
+++ b/src/mcp_dbutils/base.py
@@ -718,6 +718,10 @@ class ConnectionServer:
                     # 在生产环境中使用新的适配器
                     from .mysql.adapted_handler import AdaptedMySQLHandler
                     return AdaptedMySQLHandler(self.config_path, connection, self.debug)
+            elif db_type == "mongodb":
+                # MongoDB只有新的适配器实现
+                from .mongo.adapted_handler import AdaptedMongoDBHandler
+                return AdaptedMongoDBHandler(self.config_path, connection, self.debug)
             else:
                 raise ConfigurationError(f"Unsupported database type: {db_type}")
         except ImportError as e:

--- a/src/mcp_dbutils/mongo/__init__.py
+++ b/src/mcp_dbutils/mongo/__init__.py
@@ -1,0 +1,1 @@
+"""MongoDB module"""

--- a/src/mcp_dbutils/mongo/adapted_handler.py
+++ b/src/mcp_dbutils/mongo/adapted_handler.py
@@ -1,0 +1,424 @@
+"""
+MongoDB适配器实现
+
+这个模块实现了MongoDB的适配器，将ConnectionHandler接口适配到新架构的ConnectionBase和AdapterBase。
+"""
+
+from typing import Any, Dict, List
+
+import mcp.types as types
+
+from ..adapter import MULTI_DB_AVAILABLE, AdaptedConnectionHandler
+from ..base import ConnectionHandlerError
+from .config import MongoDBConfig
+
+
+class AdaptedMongoDBHandler(AdaptedConnectionHandler):
+    """
+    MongoDB适配器实现
+
+    这个类继承自AdaptedConnectionHandler，实现了MongoDB特定的适配逻辑。
+    """
+
+    @property
+    def db_type(self) -> str:
+        """
+        返回数据库类型
+
+        Returns:
+            str: 数据库类型
+        """
+        return 'mongodb'
+
+    def _load_config(self) -> Dict[str, Any]:
+        """
+        加载配置
+
+        从配置文件加载MongoDB配置，并转换为新架构的配置格式。
+
+        Returns:
+            Dict[str, Any]: 新架构的配置
+        """
+        config = MongoDBConfig.from_yaml(self.config_path, self.connection)
+        return {
+            'type': 'mongodb',
+            'host': config.host,
+            'port': int(config.port),
+            'database': config.database,
+            'username': config.username,
+            'password': config.password,
+            'auth_source': config.auth_source,
+            'uri': config.uri,
+            'debug': config.debug,
+            'writable': config.writable,
+            'write_permissions': config.write_permissions.to_dict() if config.write_permissions else None,
+        }
+
+    async def get_tables(self) -> list[types.Resource]:
+        """
+        获取集合资源列表
+
+        Returns:
+            list[types.Resource]: 集合资源列表
+
+        Raises:
+            ConnectionHandlerError: 如果获取集合列表失败
+        """
+        connection, adapter = self._ensure_connection()
+        try:
+            # 使用适配器的list_resources方法获取集合列表
+            collections = adapter.list_resources()
+
+            # 转换为Resource对象
+            return [
+                types.Resource(
+                    uri=f"mongodb://{self.connection}/{collection['name']}/schema",
+                    name=f"{collection['name']} schema",
+                    description=f"Documents: {collection['count']}, Size: {collection['size']} bytes",
+                    mimeType="application/json"
+                ) for collection in collections
+            ]
+        except Exception as e:
+            self.log("error", f"Failed to get collections: {str(e)}")
+            self.stats.record_error(e.__class__.__name__)
+            raise ConnectionHandlerError(f"Failed to get collections: {str(e)}")
+
+    async def get_schema(self, collection_name: str) -> str:
+        """
+        获取集合结构信息
+
+        Args:
+            collection_name: 集合名
+
+        Returns:
+            str: 集合结构信息
+
+        Raises:
+            ConnectionHandlerError: 如果获取集合结构失败
+        """
+        connection, adapter = self._ensure_connection()
+        try:
+            # 使用适配器的describe_resource方法获取集合结构
+            collection_info = adapter.describe_resource(collection_name)
+
+            # 转换为字典格式
+            schema = {
+                'name': collection_info['name'],
+                'type': collection_info['type'],
+                'fields': collection_info['fields'],
+                'indexes': collection_info['indexes'],
+            }
+
+            return str(schema)
+        except Exception as e:
+            self.log("error", f"Failed to get schema for collection {collection_name}: {str(e)}")
+            self.stats.record_error(e.__class__.__name__)
+            raise ConnectionHandlerError(f"Failed to get schema for collection {collection_name}: {str(e)}")
+
+    async def _execute_query(self, query_str: str) -> str:
+        """
+        执行MongoDB查询
+
+        Args:
+            query_str: MongoDB查询字符串（JSON格式）
+
+        Returns:
+            str: 查询结果
+
+        Raises:
+            ConnectionHandlerError: 如果执行查询失败
+        """
+        connection, adapter = self._ensure_connection()
+        try:
+            # 解析查询字符串为字典
+            import json
+            query = json.loads(query_str)
+
+            # 执行查询
+            result = adapter.execute_query(query)
+
+            # 格式化结果
+            return self._format_result(result)
+        except Exception as e:
+            self.log("error", f"Failed to execute query: {str(e)}")
+            self.stats.record_error(e.__class__.__name__)
+            raise ConnectionHandlerError(f"Failed to execute query: {str(e)}")
+
+    async def _execute_write_query(self, query_str: str) -> str:
+        """
+        执行MongoDB写操作
+
+        Args:
+            query_str: MongoDB写操作字符串（JSON格式）
+
+        Returns:
+            str: 操作结果
+
+        Raises:
+            ConnectionHandlerError: 如果执行写操作失败
+        """
+        connection, adapter = self._ensure_connection()
+        try:
+            # 解析查询字符串为字典
+            import json
+            query = json.loads(query_str)
+
+            # 执行写操作
+            result = adapter.execute_write(query)
+
+            # 格式化结果
+            return self._format_result(result)
+        except Exception as e:
+            self.log("error", f"Failed to execute write operation: {str(e)}")
+            self.stats.record_error(e.__class__.__name__)
+            raise ConnectionHandlerError(f"Failed to execute write operation: {str(e)}")
+
+    def _format_result(self, result: Any) -> str:
+        """
+        格式化结果
+
+        将新架构的结果格式转换为ConnectionHandler的结果格式。
+
+        Args:
+            result: 新架构的结果
+
+        Returns:
+            str: 格式化后的结果
+        """
+        # 如果结果是列表或字典，直接转换为字符串
+        return str(result)
+
+    async def get_table_description(self, collection_name: str) -> str:
+        """
+        获取集合描述信息
+
+        Args:
+            collection_name: 集合名
+
+        Returns:
+            str: 集合描述信息
+
+        Raises:
+            ConnectionHandlerError: 如果获取集合描述失败
+        """
+        connection, adapter = self._ensure_connection()
+        try:
+            # 使用适配器的describe_resource方法获取集合结构
+            collection_info = adapter.describe_resource(collection_name)
+
+            # 格式化输出
+            description = [
+                f"Collection: {collection_info['name']}",
+                f"Type: {collection_info['type']}",
+                f"Document Count: {collection_info['count']}",
+                f"Size: {collection_info['size']} bytes",
+                f"Average Object Size: {collection_info['avg_obj_size']} bytes",
+                f"Storage Size: {collection_info['storage_size']} bytes",
+                f"Index Size: {collection_info['index_size']} bytes",
+                f"Total Size: {collection_info['total_size']} bytes\n",
+                "Fields:"
+            ]
+
+            # 添加字段信息
+            for field in collection_info['fields']:
+                field_info = [
+                    f"  {field['name']} ({field['type']})",
+                    f"    Sample Value: {field['sample_value']}"
+                ]
+                description.extend(field_info)
+                description.append("")  # 空行分隔字段
+
+            # 添加索引信息
+            description.append("Indexes:")
+            for index in collection_info['indexes']:
+                index_info = [
+                    f"  {index['name']}:",
+                    f"    Unique: {index['unique']}",
+                    f"    Columns: {', '.join(index['columns'])}",
+                    f"    Directions: {', '.join([str(d) for d in index['directions']])}"
+                ]
+                description.extend(index_info)
+                description.append("")  # 空行分隔索引
+
+            return "\n".join(description)
+        except Exception as e:
+            self.log("error", f"Failed to get description for collection {collection_name}: {str(e)}")
+            self.stats.record_error(e.__class__.__name__)
+            raise ConnectionHandlerError(f"Failed to get description for collection {collection_name}: {str(e)}")
+
+    async def get_table_stats(self, collection_name: str) -> str:
+        """
+        获取集合统计信息
+
+        Args:
+            collection_name: 集合名
+
+        Returns:
+            str: 集合统计信息
+
+        Raises:
+            ConnectionHandlerError: 如果获取集合统计失败
+        """
+        connection, adapter = self._ensure_connection()
+        try:
+            # 使用适配器的get_resource_stats方法获取集合统计信息
+            stats = adapter.get_resource_stats(collection_name)
+
+            # 格式化输出
+            output = [
+                f"Collection Statistics for {collection_name}:",
+                f"  Document Count: {stats['count']:,}",
+                f"  Size: {stats['size']:,} bytes",
+                f"  Average Object Size: {stats['avg_obj_size']:,.1f} bytes",
+                f"  Storage Size: {stats['storage_size']:,} bytes",
+                f"  Index Size: {stats['index_size']:,} bytes",
+                f"  Total Size: {stats['total_size']:,} bytes"
+            ]
+
+            return "\n".join(output)
+        except Exception as e:
+            self.log("error", f"Failed to get statistics for collection {collection_name}: {str(e)}")
+            self.stats.record_error(e.__class__.__name__)
+            raise ConnectionHandlerError(f"Failed to get statistics for collection {collection_name}: {str(e)}")
+
+    async def get_table_indexes(self, collection_name: str) -> str:
+        """
+        获取集合索引信息
+
+        Args:
+            collection_name: 集合名
+
+        Returns:
+            str: 集合索引信息
+
+        Raises:
+            ConnectionHandlerError: 如果获取集合索引失败
+        """
+        connection, adapter = self._ensure_connection()
+        try:
+            # 使用适配器的describe_resource方法获取集合结构
+            collection_info = adapter.describe_resource(collection_name)
+
+            # 获取索引信息
+            indexes = collection_info['indexes']
+
+            if not indexes:
+                return f"No indexes found on collection {collection_name}"
+
+            # 格式化输出
+            output = [f"Indexes for collection {collection_name}:"]
+
+            for index in indexes:
+                index_info = [
+                    f"\nIndex: {index['name']}",
+                    f"  Unique: {index['unique']}",
+                    f"  Columns: {', '.join(index['columns'])}",
+                    f"  Directions: {', '.join([str(d) for d in index['directions']])}"
+                ]
+                output.extend(index_info)
+
+            return "\n".join(output)
+        except Exception as e:
+            self.log("error", f"Failed to get indexes for collection {collection_name}: {str(e)}")
+            self.stats.record_error(e.__class__.__name__)
+            raise ConnectionHandlerError(f"Failed to get indexes for collection {collection_name}: {str(e)}")
+
+    async def explain_query(self, query_str: str) -> str:
+        """
+        获取查询执行计划
+
+        Args:
+            query_str: MongoDB查询字符串（JSON格式）
+
+        Returns:
+            str: 查询执行计划
+
+        Raises:
+            ConnectionHandlerError: 如果获取查询执行计划失败
+        """
+        connection, adapter = self._ensure_connection()
+        try:
+            # 解析查询字符串为字典
+            import json
+            query = json.loads(query_str)
+
+            # 确保查询包含必要的字段
+            if 'operation' not in query or 'collection' not in query:
+                raise ConnectionHandlerError("Query must include 'operation' and 'collection' fields")
+
+            # 只支持find和aggregate操作的执行计划
+            if query['operation'] not in ['find', 'aggregate']:
+                raise ConnectionHandlerError(f"Explain is only supported for 'find' and 'aggregate' operations, got '{query['operation']}'")
+
+            # 添加explain选项
+            explain_query = query.copy()
+            if 'params' not in explain_query:
+                explain_query['params'] = {}
+
+            # 对于find操作，添加explain选项
+            if query['operation'] == 'find':
+                # 创建一个新的查询，使用aggregate和$explain阶段
+                explain_query = {
+                    'operation': 'aggregate',
+                    'collection': query['collection'],
+                    'params': {
+                        'pipeline': [
+                            {'$match': query.get('params', {}).get('filter', {})},
+                            {'$explain': {}}
+                        ]
+                    }
+                }
+            # 对于aggregate操作，添加$explain阶段
+            elif query['operation'] == 'aggregate':
+                pipeline = explain_query['params'].get('pipeline', [])
+                explain_query['params']['pipeline'] = pipeline + [{'$explain': {}}]
+
+            # 执行查询
+            result = adapter.execute_query(explain_query)
+
+            # 格式化输出
+            output = ["Query Execution Plan:"]
+            output.append(json.dumps(result, indent=2))
+
+            return "\n".join(output)
+        except Exception as e:
+            self.log("error", f"Failed to explain query: {str(e)}")
+            self.stats.record_error(e.__class__.__name__)
+            raise ConnectionHandlerError(f"Failed to explain query: {str(e)}")
+
+    async def test_connection(self) -> bool:
+        """
+        测试数据库连接
+
+        Returns:
+            bool: 如果连接成功，则返回True，否则返回False
+        """
+        try:
+            # 只需要确保连接可以建立，不需要使用连接对象
+            self._ensure_connection()
+            return True
+        except Exception as e:
+            self.log("error", f"Connection test failed: {str(e)}")
+            return False
+
+    async def cleanup(self):
+        """
+        清理资源
+
+        关闭连接并清理资源。
+        """
+        # 记录最终统计信息
+        self.log("info", f"Final handler stats: {self.stats.to_dict()}")
+
+        # 关闭连接
+        if self._connection and hasattr(self._connection, 'is_connected') and self._connection.is_connected():
+            try:
+                self.log("debug", f"Closing {self.db_type} connection")
+                self._connection.disconnect()
+                self._connection = None
+                self._adapter = None
+            except Exception as e:
+                self.log("warning", f"Error closing {self.db_type} connection: {str(e)}")
+
+        # 清理其他资源
+        self.log("debug", f"{self.db_type} handler cleanup complete")

--- a/src/mcp_dbutils/mongo/config.py
+++ b/src/mcp_dbutils/mongo/config.py
@@ -1,0 +1,129 @@
+"""MongoDB configuration module"""
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Optional
+from urllib.parse import parse_qs, urlparse
+
+from ..config import ConnectionConfig, WritePermissions
+
+
+@dataclass
+class MongoDBConfig(ConnectionConfig):
+    """MongoDB connection configuration"""
+    host: str = 'localhost'
+    port: str = '27017'
+    database: str
+    username: Optional[str] = None
+    password: Optional[str] = None
+    auth_source: str = 'admin'
+    uri: Optional[str] = None
+    type: Literal['mongodb'] = 'mongodb'
+    writable: bool = False  # Whether write operations are allowed
+    write_permissions: Optional[WritePermissions] = None  # Write permissions configuration
+
+    @classmethod
+    def from_yaml(cls, yaml_path: str, db_name: str) -> 'MongoDBConfig':
+        """Create configuration from YAML file
+
+        Args:
+            yaml_path: Path to YAML configuration file
+            db_name: Connection configuration name to use
+        """
+        configs = cls.load_yaml_config(yaml_path)
+        if not db_name:
+            raise ValueError("Connection name must be specified")
+        if db_name not in configs:
+            available_dbs = list(configs.keys())
+            raise ValueError(f"Connection configuration not found: {db_name}. Available configurations: {available_dbs}")
+
+        db_config = configs[db_name]
+        if 'type' not in db_config:
+            raise ValueError("Connection configuration must include 'type' field")
+        if db_config['type'] != 'mongodb':
+            raise ValueError(f"Configuration is not MongoDB type: {db_config['type']}")
+
+        # Get connection parameters
+        if 'uri' in db_config:
+            # Parse URI for connection parameters
+            uri = db_config['uri']
+            parsed = urlparse(uri)
+            
+            # Extract database name from URI
+            database = parsed.path.lstrip('/') if parsed.path else db_config.get('database')
+            if not database:
+                raise ValueError("MongoDB database name must be specified in configuration or URI")
+            
+            # Extract host and port from URI
+            host = parsed.hostname or 'localhost'
+            port = str(parsed.port or 27017)
+            
+            # Extract username and password from URI
+            username = parsed.username
+            password = parsed.password
+            
+            # Extract auth_source from query parameters
+            query_params = parse_qs(parsed.query)
+            auth_source = query_params.get('authSource', ['admin'])[0]
+            
+            config = cls(
+                database=database,
+                host=host,
+                port=port,
+                username=username,
+                password=password,
+                auth_source=auth_source,
+                uri=uri
+            )
+        else:
+            # Use explicit configuration parameters
+            if 'database' not in db_config:
+                raise ValueError("MongoDB database name must be specified in configuration")
+            
+            config = cls(
+                database=db_config['database'],
+                host=db_config.get('host', 'localhost'),
+                port=str(db_config.get('port', 27017)),
+                username=db_config.get('username'),
+                password=db_config.get('password'),
+                auth_source=db_config.get('auth_source', 'admin')
+            )
+
+        # Parse write permissions
+        config.writable = db_config.get('writable', False)
+        if config.writable and 'write_permissions' in db_config:
+            config.write_permissions = WritePermissions(db_config['write_permissions'])
+
+        config.debug = cls.get_debug_mode()
+        return config
+
+    def get_connection_params(self) -> Dict[str, Any]:
+        """Get MongoDB connection parameters"""
+        if self.uri:
+            return {'uri': self.uri}
+        
+        params = {
+            'host': self.host,
+            'port': int(self.port),
+            'database': self.database,
+            'auth_source': self.auth_source
+        }
+        
+        if self.username:
+            params['username'] = self.username
+        if self.password:
+            params['password'] = self.password
+            
+        return params
+
+    def get_masked_connection_info(self) -> Dict[str, Any]:
+        """Return masked connection information for logging"""
+        info = {
+            'host': self.host,
+            'port': self.port,
+            'database': self.database,
+            'auth_source': self.auth_source
+        }
+        
+        if self.username:
+            info['username'] = self.username
+            
+        return info

--- a/tests/unit/test_mongo_adapted_handler.py
+++ b/tests/unit/test_mongo_adapted_handler.py
@@ -1,0 +1,192 @@
+"""
+MongoDB适配器单元测试
+
+这个模块包含MongoDB适配器的单元测试。
+"""
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+import mcp.types as types
+
+from mcp_dbutils.base import ConnectionHandlerError
+from mcp_dbutils.mongo.adapted_handler import AdaptedMongoDBHandler
+
+
+class TestMongoDBAdaptedHandler(unittest.TestCase):
+    """MongoDB适配器单元测试类"""
+
+    def setUp(self):
+        """设置测试环境"""
+        # 创建一个模拟的配置路径和连接名
+        self.config_path = "test_config.yaml"
+        self.connection = "test_mongodb"
+        
+        # 模拟配置加载
+        self.config_mock = {
+            'type': 'mongodb',
+            'host': 'localhost',
+            'port': 27017,
+            'database': 'test_db',
+            'username': 'test_user',
+            'password': 'test_password',
+            'auth_source': 'admin',
+            'debug': True,
+            'writable': True,
+            'write_permissions': {'default_policy': 'deny_all', 'tables': {}}
+        }
+        
+        # 创建MongoDB适配器
+        with patch('mcp_dbutils.mongo.config.MongoDBConfig.from_yaml', return_value=MagicMock(
+            host='localhost',
+            port='27017',
+            database='test_db',
+            username='test_user',
+            password='test_password',
+            auth_source='admin',
+            uri=None,
+            debug=True,
+            writable=True,
+            write_permissions=None,
+            to_dict=lambda: self.config_mock
+        )):
+            self.handler = AdaptedMongoDBHandler(self.config_path, self.connection, debug=True)
+        
+        # 模拟连接和适配器
+        self.handler._connection = MagicMock()
+        self.handler._adapter = MagicMock()
+        self.handler._ensure_connection = MagicMock(return_value=(self.handler._connection, self.handler._adapter))
+
+    def test_db_type(self):
+        """测试数据库类型属性"""
+        self.assertEqual(self.handler.db_type, 'mongodb')
+
+    def test_load_config(self):
+        """测试加载配置"""
+        with patch('mcp_dbutils.mongo.config.MongoDBConfig.from_yaml', return_value=MagicMock(
+            host='localhost',
+            port='27017',
+            database='test_db',
+            username='test_user',
+            password='test_password',
+            auth_source='admin',
+            uri=None,
+            debug=True,
+            writable=True,
+            write_permissions=None,
+            to_dict=lambda: self.config_mock
+        )):
+            config = self.handler._load_config()
+            self.assertEqual(config['type'], 'mongodb')
+            self.assertEqual(config['host'], 'localhost')
+            self.assertEqual(config['port'], 27017)
+            self.assertEqual(config['database'], 'test_db')
+            self.assertEqual(config['username'], 'test_user')
+            self.assertEqual(config['password'], 'test_password')
+            self.assertEqual(config['auth_source'], 'admin')
+            self.assertEqual(config['debug'], True)
+            self.assertEqual(config['writable'], True)
+
+    def test_get_tables(self):
+        """测试获取集合列表"""
+        # 模拟适配器的list_resources方法
+        collections = [
+            {'name': 'users', 'type': 'COLLECTION', 'count': 10, 'size': 1024},
+            {'name': 'products', 'type': 'COLLECTION', 'count': 5, 'size': 512}
+        ]
+        self.handler._adapter.list_resources.return_value = collections
+        
+        # 执行测试
+        result = self.handler.get_tables()
+        
+        # 验证结果
+        self.assertEqual(len(result), 2)
+        self.assertEqual(result[0].name, 'users schema')
+        self.assertEqual(result[0].uri, 'mongodb://test_mongodb/users/schema')
+        self.assertEqual(result[1].name, 'products schema')
+        self.assertEqual(result[1].uri, 'mongodb://test_mongodb/products/schema')
+
+    def test_get_schema(self):
+        """测试获取集合结构"""
+        # 模拟适配器的describe_resource方法
+        collection_info = {
+            'name': 'users',
+            'type': 'COLLECTION',
+            'fields': [
+                {'name': '_id', 'type': 'ObjectId', 'sample_value': '60b9b4b9e6b3f3b3e8b4b4b9'},
+                {'name': 'name', 'type': 'str', 'sample_value': 'John'}
+            ],
+            'indexes': [
+                {'name': '_id_', 'unique': True, 'columns': ['_id'], 'directions': [1]}
+            ]
+        }
+        self.handler._adapter.describe_resource.return_value = collection_info
+        
+        # 执行测试
+        result = self.handler.get_schema('users')
+        
+        # 验证结果
+        self.assertIn('name', result)
+        self.assertIn('type', result)
+        self.assertIn('fields', result)
+        self.assertIn('indexes', result)
+
+    def test_execute_query(self):
+        """测试执行查询"""
+        # 模拟适配器的execute_query方法
+        query_result = [{'name': 'John', 'age': 25}]
+        self.handler._adapter.execute_query.return_value = query_result
+        
+        # 执行测试
+        result = self.handler._execute_query('{"operation": "find", "collection": "users", "filter": {"age": {"$gt": 18}}}')
+        
+        # 验证结果
+        self.assertEqual(result, str(query_result))
+
+    def test_execute_write_query(self):
+        """测试执行写操作"""
+        # 模拟适配器的execute_write方法
+        write_result = {'inserted_id': '123'}
+        self.handler._adapter.execute_write.return_value = write_result
+        
+        # 执行测试
+        result = self.handler._execute_write_query('{"operation": "insert_one", "collection": "users", "document": {"name": "John", "age": 25}}')
+        
+        # 验证结果
+        self.assertEqual(result, str(write_result))
+
+    def test_get_table_description(self):
+        """测试获取集合描述"""
+        # 模拟适配器的describe_resource方法
+        collection_info = {
+            'name': 'users',
+            'type': 'COLLECTION',
+            'count': 10,
+            'size': 1024,
+            'avg_obj_size': 102.4,
+            'storage_size': 2048,
+            'index_size': 512,
+            'total_size': 1536,
+            'fields': [
+                {'name': '_id', 'type': 'ObjectId', 'sample_value': '60b9b4b9e6b3f3b3e8b4b4b9'},
+                {'name': 'name', 'type': 'str', 'sample_value': 'John'}
+            ],
+            'indexes': [
+                {'name': '_id_', 'unique': True, 'columns': ['_id'], 'directions': [1]}
+            ]
+        }
+        self.handler._adapter.describe_resource.return_value = collection_info
+        
+        # 执行测试
+        result = self.handler.get_table_description('users')
+        
+        # 验证结果
+        self.assertIn('Collection: users', result)
+        self.assertIn('Document Count: 10', result)
+        self.assertIn('_id (ObjectId)', result)
+        self.assertIn('name (str)', result)
+        self.assertIn('Index: _id_', result)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
实现了MongoDB适配器，将MongoDB处理器适配到新架构。

1. 创建AdaptedMongoDBHandler类，继承自AdaptedConnectionHandler，实现MongoDB特定的适配逻辑
2. 实现MongoDB适配器的所有必要方法，包括集合操作、查询执行等
3. 修改ConnectionServer._create_handler_for_type方法，使其支持MongoDB适配器
4. 添加MongoDB适配器的单元测试

Related to #93