### PR TITLE
fix: 修改文档中的Docker安装说明，添加获取项目代码步骤

### DIFF
--- a/docs/ar/installation-platform-specific.md
+++ b/docs/ar/installation-platform-specific.md
@@ -214,21 +214,11 @@ npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
 - Docker مثبت ويعمل
 - اتصال بالإنترنت (لتنزيل صورة Docker)
 
-### استخدام صورة Docker الرسمية
+### بناء صورة Docker محلية
 
-1. قم بسحب صورة Docker:
-   ```bash
-   docker pull mcp/dbutils
-   ```
+بسبب قيود الشبكة في بعض المناطق، نوصي ببناء صورة Docker محلياً:
 
-2. قم بتشغيل الحاوية مع ملف التكوين الخاص بك:
-   ```bash
-   docker run -i --rm -v /path/to/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
-   ```
-
-### إنشاء صورة Docker مخصصة
-
-إذا كنت بحاجة إلى تخصيص صورة Docker، يمكنك إنشاء Dockerfile الخاص بك:
+1. قم بإنشاء Dockerfile:
 
 ```dockerfile
 FROM python:3.10-slim
@@ -241,12 +231,19 @@ ENTRYPOINT ["mcp-dbutils"]
 CMD ["--help"]
 ```
 
-قم ببناء وتشغيل صورتك المخصصة:
+2. قم ببناء الصورة:
 
 ```bash
-docker build -t custom-mcp-dbutils .
-docker run -i --rm -v /path/to/config.yaml:/app/config.yaml custom-mcp-dbutils --config /app/config.yaml
+docker build -t mcp/dbutils .
 ```
+
+3. قم بتشغيل الحاوية:
+
+```bash
+docker run -i --rm -v /path/to/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
+```
+
+> **ملاحظة**: للتحديث إلى أحدث إصدار، ستحتاج إلى إعادة بناء الصورة للحصول على أحدث إصدار من MCP Database Utilities.
 
 ## التثبيت بدون اتصال بالإنترنت
 

--- a/docs/ar/installation-platform-specific.md
+++ b/docs/ar/installation-platform-specific.md
@@ -214,36 +214,30 @@ npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
 - Docker مثبت ويعمل
 - اتصال بالإنترنت (لتنزيل صورة Docker)
 
-### بناء صورة Docker محلية
+### استخدام صورة Docker
 
-بسبب قيود الشبكة في بعض المناطق، نوصي ببناء صورة Docker محلياً:
+1. احصل على كود المشروع:
+   ```bash
+   git clone https://github.com/donghao1393/mcp-dbutils.git
+   ```
+   أو قم بتنزيل أحدث إصدار من [صفحة الإصدارات](https://github.com/donghao1393/mcp-dbutils/releases) واستخراجه
 
-1. قم بإنشاء Dockerfile:
+2. انتقل إلى دليل المشروع:
+   ```bash
+   cd mcp-dbutils
+   ```
 
-```dockerfile
-FROM python:3.10-slim
+3. قم ببناء صورة MCP Database Utilities:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
+4. قم بتكوين تطبيق الذكاء الاصطناعي الخاص بك لاستخدام هذه الصورة (انظر [دليل التثبيت](installation.md) الخيار ب)
 
-RUN pip install --no-cache-dir mcp-dbutils
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--help"]
-```
-
-2. قم ببناء الصورة:
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-3. قم بتشغيل الحاوية:
-
-```bash
-docker run -i --rm -v /path/to/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
-```
-
-> **ملاحظة**: للتحديث إلى أحدث إصدار، ستحتاج إلى إعادة بناء الصورة للحصول على أحدث إصدار من MCP Database Utilities.
+> **ملاحظة**:
+> - يحتوي دليل المشروع الجذر بالفعل على Dockerfile، لذلك لا تحتاج إلى إنشاء واحد يدويًا
+> - للتحديث إلى أحدث إصدار، ستحتاج إلى الحصول على أحدث كود وإعادة بناء الصورة
+> - هذه خدمة MCP، مخصصة بشكل أساسي ليتم استدعاؤها بواسطة LLMs في تطبيقات الذكاء الاصطناعي، وليس لتشغيلها كخدمة مستقلة
 
 ## التثبيت بدون اتصال بالإنترنت
 

--- a/docs/ar/installation.md
+++ b/docs/ar/installation.md
@@ -132,7 +132,31 @@ connections:
 
 نفس الخطوة 2 في الخيار أ، قم بإنشاء ملف `config.yaml`.
 
-### الخطوة 3: تكوين تطبيق الذكاء الاصطناعي الخاص بك
+### الخطوة 3: بناء صورة Docker
+
+1. قم بإنشاء ملف باسم `Dockerfile` (بدون امتداد) بالمحتوى التالي:
+
+```dockerfile
+FROM python:3.10-slim
+
+RUN pip install --no-cache-dir mcp-dbutils
+
+WORKDIR /app
+COPY config.yaml /app/config.yaml
+
+ENTRYPOINT ["mcp-dbutils"]
+CMD ["--config", "/app/config.yaml"]
+```
+
+2. قم ببناء الصورة بتنفيذ الأمر التالي في الدليل الذي يحتوي على Dockerfile:
+
+```bash
+docker build -t mcp/dbutils .
+```
+
+> **ملاحظة**: للتحديث إلى أحدث إصدار، ستحتاج إلى إعادة بناء الصورة للحصول على أحدث إصدار من MCP Database Utilities.
+
+### الخطوة 4: تكوين تطبيق الذكاء الاصطناعي الخاص بك
 
 #### تكوين Claude Desktop
 
@@ -304,8 +328,10 @@ uv pip install -U mcp-dbutils
 
 ### تحديث الخيار ب (Docker)
 
+أعد بناء صورة Docker الخاصة بك للحصول على أحدث إصدار:
+
 ```bash
-docker pull mcp/dbutils:latest
+docker build -t mcp/dbutils .
 ```
 
 ### تحديث الخيار ج (Smithery)

--- a/docs/ar/installation.md
+++ b/docs/ar/installation.md
@@ -132,29 +132,23 @@ connections:
 
 نفس الخطوة 2 في الخيار أ، قم بإنشاء ملف `config.yaml`.
 
-### الخطوة 3: بناء صورة Docker
+### الخطوة 3: الحصول على كود المشروع وبناء صورة Docker
 
-1. قم بإنشاء ملف باسم `Dockerfile` (بدون امتداد) بالمحتوى التالي:
+1. أولاً، احصل على كود المشروع (اختر إحدى الطرق التالية):
+   - استنساخ المشروع من GitHub: `git clone https://github.com/donghao1393/mcp-dbutils.git`
+   - أو قم بتنزيل أحدث إصدار من [صفحة الإصدارات](https://github.com/donghao1393/mcp-dbutils/releases) واستخراجه
 
-```dockerfile
-FROM python:3.10-slim
+2. انتقل إلى دليل المشروع:
+   ```bash
+   cd mcp-dbutils
+   ```
 
-RUN pip install --no-cache-dir mcp-dbutils
+3. قم ببناء صورة Docker:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
-COPY config.yaml /app/config.yaml
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--config", "/app/config.yaml"]
-```
-
-2. قم ببناء الصورة بتنفيذ الأمر التالي في الدليل الذي يحتوي على Dockerfile:
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-> **ملاحظة**: للتحديث إلى أحدث إصدار، ستحتاج إلى إعادة بناء الصورة للحصول على أحدث إصدار من MCP Database Utilities.
+> **ملاحظة**: يحتوي دليل المشروع الجذر بالفعل على Dockerfile، لذلك لا تحتاج إلى إنشاء واحد يدويًا. للتحديث إلى أحدث إصدار، ستحتاج إلى الحصول على أحدث كود وإعادة بناء الصورة.
 
 ### الخطوة 4: تكوين تطبيق الذكاء الاصطناعي الخاص بك
 
@@ -328,11 +322,16 @@ uv pip install -U mcp-dbutils
 
 ### تحديث الخيار ب (Docker)
 
-أعد بناء صورة Docker الخاصة بك للحصول على أحدث إصدار:
+1. احصل على أحدث كود للمشروع:
+   ```bash
+   git pull
+   ```
+   أو قم بتنزيل أحدث إصدار من [صفحة الإصدارات](https://github.com/donghao1393/mcp-dbutils/releases)
 
-```bash
-docker build -t mcp/dbutils .
-```
+2. أعد بناء صورة Docker الخاصة بك:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
 ### تحديث الخيار ج (Smithery)
 

--- a/docs/en/installation-platform-specific.md
+++ b/docs/en/installation-platform-specific.md
@@ -199,23 +199,9 @@ wsl --install
 
 ## Docker Installation Guide
 
-### Using Pre-built Image
+### Building a Local Image
 
-1. Pull the MCP Database Utilities image:
-
-```bash
-docker pull mcp/dbutils
-```
-
-2. Run the container:
-
-```bash
-docker run -i --rm \
-  -v /path/to/config.yaml:/app/config.yaml \
-  mcp/dbutils --config /app/config.yaml
-```
-
-### Building a Custom Image
+Due to network restrictions in some regions, we recommend building the Docker image locally:
 
 1. Create a Dockerfile:
 
@@ -234,14 +220,18 @@ CMD ["--config", "/app/config.yaml"]
 2. Build the image:
 
 ```bash
-docker build -t custom-mcp-dbutils .
+docker build -t mcp/dbutils .
 ```
 
 3. Run the container:
 
 ```bash
-docker run -i --rm custom-mcp-dbutils
+docker run -i --rm \
+  -v /path/to/config.yaml:/app/config.yaml \
+  mcp/dbutils --config /app/config.yaml
 ```
+
+> **Note**: To update to the latest version, you'll need to rebuild the image to get the latest MCP Database Utilities version.
 
 ## Troubleshooting
 

--- a/docs/en/installation-platform-specific.md
+++ b/docs/en/installation-platform-specific.md
@@ -199,39 +199,30 @@ wsl --install
 
 ## Docker Installation Guide
 
-### Building a Local Image
+### Using Docker Image
 
-Due to network restrictions in some regions, we recommend building the Docker image locally:
+1. Get the project code:
+   ```bash
+   git clone https://github.com/donghao1393/mcp-dbutils.git
+   ```
+   Or download the latest version from the [Releases page](https://github.com/donghao1393/mcp-dbutils/releases) and extract it
 
-1. Create a Dockerfile:
+2. Navigate to the project directory:
+   ```bash
+   cd mcp-dbutils
+   ```
 
-```dockerfile
-FROM python:3.10-slim
+3. Build the MCP Database Utilities image:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-RUN pip install --no-cache-dir mcp-dbutils
+4. Configure your AI application to use this image (see [Installation Guide](installation.md) Option B)
 
-WORKDIR /app
-COPY config.yaml /app/config.yaml
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--config", "/app/config.yaml"]
-```
-
-2. Build the image:
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-3. Run the container:
-
-```bash
-docker run -i --rm \
-  -v /path/to/config.yaml:/app/config.yaml \
-  mcp/dbutils --config /app/config.yaml
-```
-
-> **Note**: To update to the latest version, you'll need to rebuild the image to get the latest MCP Database Utilities version.
+> **Note**:
+> - The project root directory already includes a Dockerfile, so you don't need to create one manually
+> - To update to the latest version, you'll need to get the latest code and rebuild the image
+> - This is an MCP service, primarily intended to be called by LLMs in AI applications, not to be run as a standalone service
 
 ## Troubleshooting
 

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -133,29 +133,23 @@ If you don't have Docker installed, download and install it from [docker.com](ht
 
 Same as Step 2 in Option A, create a `config.yaml` file.
 
-### Step 3: Build the Docker image
+### Step 3: Get the project code and build the Docker image
 
-1. Create a file named `Dockerfile` (without any extension) with the following content:
+1. First, get the project code (choose one of the following methods):
+   - Clone the project from GitHub: `git clone https://github.com/donghao1393/mcp-dbutils.git`
+   - Or download the latest version from the [Releases page](https://github.com/donghao1393/mcp-dbutils/releases) and extract it
 
-```dockerfile
-FROM python:3.10-slim
+2. Navigate to the project directory:
+   ```bash
+   cd mcp-dbutils
+   ```
 
-RUN pip install --no-cache-dir mcp-dbutils
+3. Build the Docker image:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
-COPY config.yaml /app/config.yaml
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--config", "/app/config.yaml"]
-```
-
-2. Build the image by running the following command in the directory containing the Dockerfile:
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-> **Note**: To update to the latest version, you'll need to rebuild the image to get the latest MCP Database Utilities version.
+> **Note**: The project root directory already includes a Dockerfile, so you don't need to create one manually. To update to the latest version, you'll need to get the latest code and rebuild the image.
 
 ### Step 4: Configure your AI application
 
@@ -329,11 +323,16 @@ uv pip install -U mcp-dbutils
 
 ### Option B (Docker) Update
 
-Rebuild your Docker image to get the latest version:
+1. Get the latest project code:
+   ```bash
+   git pull
+   ```
+   Or download the latest version from the [Releases page](https://github.com/donghao1393/mcp-dbutils/releases)
 
-```bash
-docker build -t mcp/dbutils .
-```
+2. Rebuild your Docker image:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
 ### Option C (Smithery) Update
 

--- a/docs/en/installation.md
+++ b/docs/en/installation.md
@@ -133,7 +133,31 @@ If you don't have Docker installed, download and install it from [docker.com](ht
 
 Same as Step 2 in Option A, create a `config.yaml` file.
 
-### Step 3: Configure your AI application
+### Step 3: Build the Docker image
+
+1. Create a file named `Dockerfile` (without any extension) with the following content:
+
+```dockerfile
+FROM python:3.10-slim
+
+RUN pip install --no-cache-dir mcp-dbutils
+
+WORKDIR /app
+COPY config.yaml /app/config.yaml
+
+ENTRYPOINT ["mcp-dbutils"]
+CMD ["--config", "/app/config.yaml"]
+```
+
+2. Build the image by running the following command in the directory containing the Dockerfile:
+
+```bash
+docker build -t mcp/dbutils .
+```
+
+> **Note**: To update to the latest version, you'll need to rebuild the image to get the latest MCP Database Utilities version.
+
+### Step 4: Configure your AI application
 
 #### Claude Desktop Configuration
 
@@ -305,8 +329,10 @@ uv pip install -U mcp-dbutils
 
 ### Option B (Docker) Update
 
+Rebuild your Docker image to get the latest version:
+
 ```bash
-docker pull mcp/dbutils:latest
+docker build -t mcp/dbutils .
 ```
 
 ### Option C (Smithery) Update

--- a/docs/es/installation-platform-specific.md
+++ b/docs/es/installation-platform-specific.md
@@ -214,21 +214,11 @@ npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
 - Docker instalado y funcionando
 - Conexión a Internet (para descargar la imagen Docker)
 
-### Uso de la Imagen Docker Oficial
+### Construcción de una Imagen Docker Local
 
-1. Descargue la imagen Docker:
-   ```bash
-   docker pull mcp/dbutils
-   ```
+Debido a restricciones de red en algunas regiones, recomendamos construir la imagen Docker localmente:
 
-2. Ejecute el contenedor con su archivo de configuración:
-   ```bash
-   docker run -i --rm -v /ruta/a/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
-   ```
-
-### Creación de una Imagen Docker Personalizada
-
-Si necesita personalizar la imagen Docker, puede crear su propio Dockerfile:
+1. Cree un Dockerfile:
 
 ```dockerfile
 FROM python:3.10-slim
@@ -241,12 +231,19 @@ ENTRYPOINT ["mcp-dbutils"]
 CMD ["--help"]
 ```
 
-Construya y ejecute su imagen personalizada:
+2. Construya la imagen:
 
 ```bash
-docker build -t custom-mcp-dbutils .
-docker run -i --rm -v /ruta/a/config.yaml:/app/config.yaml custom-mcp-dbutils --config /app/config.yaml
+docker build -t mcp/dbutils .
 ```
+
+3. Ejecute el contenedor:
+
+```bash
+docker run -i --rm -v /ruta/a/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
+```
+
+> **Nota**: Para actualizar a la última versión, necesitará reconstruir la imagen para obtener la versión más reciente de MCP Database Utilities.
 
 ## Instalación Sin Conexión
 

--- a/docs/es/installation-platform-specific.md
+++ b/docs/es/installation-platform-specific.md
@@ -214,36 +214,30 @@ npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
 - Docker instalado y funcionando
 - Conexión a Internet (para descargar la imagen Docker)
 
-### Construcción de una Imagen Docker Local
+### Uso de la Imagen Docker
 
-Debido a restricciones de red en algunas regiones, recomendamos construir la imagen Docker localmente:
+1. Obtenga el código del proyecto:
+   ```bash
+   git clone https://github.com/donghao1393/mcp-dbutils.git
+   ```
+   O descargue la última versión desde la [página de Releases](https://github.com/donghao1393/mcp-dbutils/releases) y extráigala
 
-1. Cree un Dockerfile:
+2. Navegue al directorio del proyecto:
+   ```bash
+   cd mcp-dbutils
+   ```
 
-```dockerfile
-FROM python:3.10-slim
+3. Construya la imagen MCP Database Utilities:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
+4. Configure su aplicación de IA para usar esta imagen (vea la [Guía de Instalación](installation.md) Opción B)
 
-RUN pip install --no-cache-dir mcp-dbutils
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--help"]
-```
-
-2. Construya la imagen:
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-3. Ejecute el contenedor:
-
-```bash
-docker run -i --rm -v /ruta/a/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
-```
-
-> **Nota**: Para actualizar a la última versión, necesitará reconstruir la imagen para obtener la versión más reciente de MCP Database Utilities.
+> **Nota**:
+> - El directorio raíz del proyecto ya incluye un Dockerfile, por lo que no necesita crear uno manualmente
+> - Para actualizar a la última versión, necesitará obtener el código más reciente y reconstruir la imagen
+> - Este es un servicio MCP, principalmente destinado a ser llamado por LLMs en aplicaciones de IA, no para ejecutarse como un servicio independiente
 
 ## Instalación Sin Conexión
 

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -130,7 +130,31 @@ Si no tiene Docker instalado, descárguelo e instálelo desde [docker.com](https
 
 Igual que el Paso 2 en la Opción A, cree un archivo `config.yaml`.
 
-### Paso 3: Configurar su aplicación de IA
+### Paso 3: Construir la imagen Docker
+
+1. Cree un archivo llamado `Dockerfile` (sin extensión) con el siguiente contenido:
+
+```dockerfile
+FROM python:3.10-slim
+
+RUN pip install --no-cache-dir mcp-dbutils
+
+WORKDIR /app
+COPY config.yaml /app/config.yaml
+
+ENTRYPOINT ["mcp-dbutils"]
+CMD ["--config", "/app/config.yaml"]
+```
+
+2. Construya la imagen ejecutando el siguiente comando en el directorio que contiene el Dockerfile:
+
+```bash
+docker build -t mcp/dbutils .
+```
+
+> **Nota**: Para actualizar a la última versión, necesitará reconstruir la imagen para obtener la versión más reciente de MCP Database Utilities.
+
+### Paso 4: Configurar su aplicación de IA
 
 #### Configuración de Claude Desktop
 
@@ -302,8 +326,10 @@ uv pip install -U mcp-dbutils
 
 ### Actualización de Opción B (Docker)
 
+Reconstruya su imagen Docker para obtener la última versión:
+
 ```bash
-docker pull mcp/dbutils:latest
+docker build -t mcp/dbutils .
 ```
 
 ### Actualización de Opción C (Smithery)

--- a/docs/es/installation.md
+++ b/docs/es/installation.md
@@ -130,29 +130,23 @@ Si no tiene Docker instalado, descárguelo e instálelo desde [docker.com](https
 
 Igual que el Paso 2 en la Opción A, cree un archivo `config.yaml`.
 
-### Paso 3: Construir la imagen Docker
+### Paso 3: Obtener el código del proyecto y construir la imagen Docker
 
-1. Cree un archivo llamado `Dockerfile` (sin extensión) con el siguiente contenido:
+1. Primero, obtenga el código del proyecto (elija uno de los siguientes métodos):
+   - Clone el proyecto desde GitHub: `git clone https://github.com/donghao1393/mcp-dbutils.git`
+   - O descargue la última versión desde la [página de Releases](https://github.com/donghao1393/mcp-dbutils/releases) y extráigala
 
-```dockerfile
-FROM python:3.10-slim
+2. Navegue al directorio del proyecto:
+   ```bash
+   cd mcp-dbutils
+   ```
 
-RUN pip install --no-cache-dir mcp-dbutils
+3. Construya la imagen Docker:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
-COPY config.yaml /app/config.yaml
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--config", "/app/config.yaml"]
-```
-
-2. Construya la imagen ejecutando el siguiente comando en el directorio que contiene el Dockerfile:
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-> **Nota**: Para actualizar a la última versión, necesitará reconstruir la imagen para obtener la versión más reciente de MCP Database Utilities.
+> **Nota**: El directorio raíz del proyecto ya incluye un Dockerfile, por lo que no necesita crear uno manualmente. Para actualizar a la última versión, necesitará obtener el código más reciente y reconstruir la imagen.
 
 ### Paso 4: Configurar su aplicación de IA
 
@@ -326,11 +320,16 @@ uv pip install -U mcp-dbutils
 
 ### Actualización de Opción B (Docker)
 
-Reconstruya su imagen Docker para obtener la última versión:
+1. Obtenga el código del proyecto más reciente:
+   ```bash
+   git pull
+   ```
+   O descargue la última versión desde la [página de Releases](https://github.com/donghao1393/mcp-dbutils/releases)
 
-```bash
-docker build -t mcp/dbutils .
-```
+2. Reconstruya su imagen Docker:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
 ### Actualización de Opción C (Smithery)
 

--- a/docs/fr/installation-platform-specific.md
+++ b/docs/fr/installation-platform-specific.md
@@ -214,36 +214,30 @@ npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
 - Docker installé et fonctionnel
 - Connexion Internet (pour télécharger l'image Docker)
 
-### Construction d'une Image Docker Locale
+### Utilisation de l'Image Docker
 
-En raison des restrictions réseau dans certaines régions, nous recommandons de construire l'image Docker localement :
+1. Obtenez le code du projet :
+   ```bash
+   git clone https://github.com/donghao1393/mcp-dbutils.git
+   ```
+   Ou téléchargez la dernière version depuis la [page des Releases](https://github.com/donghao1393/mcp-dbutils/releases) et extrayez-la
 
-1. Créez un Dockerfile :
+2. Naviguez vers le répertoire du projet :
+   ```bash
+   cd mcp-dbutils
+   ```
 
-```dockerfile
-FROM python:3.10-slim
+3. Construisez l'image MCP Database Utilities :
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
+4. Configurez votre application IA pour utiliser cette image (voir [Guide d'installation](installation.md) Option B)
 
-RUN pip install --no-cache-dir mcp-dbutils
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--help"]
-```
-
-2. Construisez l'image :
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-3. Exécutez le conteneur :
-
-```bash
-docker run -i --rm -v /path/to/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
-```
-
-> **Remarque** : Pour mettre à jour vers la dernière version, vous devrez reconstruire l'image pour obtenir la dernière version de MCP Database Utilities.
+> **Remarque** :
+> - Le répertoire racine du projet contient déjà un Dockerfile, vous n'avez donc pas besoin d'en créer un manuellement
+> - Pour mettre à jour vers la dernière version, vous devrez obtenir le code le plus récent et reconstruire l'image
+> - Il s'agit d'un service MCP, principalement destiné à être appelé par les LLM dans les applications IA, et non à être exécuté comme un service autonome
 
 ## Installation Hors Ligne
 

--- a/docs/fr/installation-platform-specific.md
+++ b/docs/fr/installation-platform-specific.md
@@ -214,21 +214,11 @@ npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
 - Docker installé et fonctionnel
 - Connexion Internet (pour télécharger l'image Docker)
 
-### Utilisation de l'Image Docker Officielle
+### Construction d'une Image Docker Locale
 
-1. Tirez l'image Docker :
-   ```bash
-   docker pull mcp/dbutils
-   ```
+En raison des restrictions réseau dans certaines régions, nous recommandons de construire l'image Docker localement :
 
-2. Exécutez le conteneur avec votre fichier de configuration :
-   ```bash
-   docker run -i --rm -v /path/to/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
-   ```
-
-### Création d'une Image Docker Personnalisée
-
-Si vous avez besoin de personnaliser l'image Docker, vous pouvez créer votre propre Dockerfile :
+1. Créez un Dockerfile :
 
 ```dockerfile
 FROM python:3.10-slim
@@ -241,12 +231,19 @@ ENTRYPOINT ["mcp-dbutils"]
 CMD ["--help"]
 ```
 
-Construisez et exécutez votre image personnalisée :
+2. Construisez l'image :
 
 ```bash
-docker build -t custom-mcp-dbutils .
-docker run -i --rm -v /path/to/config.yaml:/app/config.yaml custom-mcp-dbutils --config /app/config.yaml
+docker build -t mcp/dbutils .
 ```
+
+3. Exécutez le conteneur :
+
+```bash
+docker run -i --rm -v /path/to/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
+```
+
+> **Remarque** : Pour mettre à jour vers la dernière version, vous devrez reconstruire l'image pour obtenir la dernière version de MCP Database Utilities.
 
 ## Installation Hors Ligne
 

--- a/docs/fr/installation.md
+++ b/docs/fr/installation.md
@@ -130,29 +130,23 @@ Si vous n'avez pas Docker installé, téléchargez et installez-le depuis [docke
 
 Identique à l'Étape 2 de l'Option A, créez un fichier `config.yaml`.
 
-### Étape 3 : Construire l'image Docker
+### Étape 3 : Obtenir le code du projet et construire l'image Docker
 
-1. Créez un fichier nommé `Dockerfile` (sans extension) avec le contenu suivant :
+1. D'abord, obtenez le code du projet (choisissez l'une des méthodes suivantes) :
+   - Clonez le projet depuis GitHub : `git clone https://github.com/donghao1393/mcp-dbutils.git`
+   - Ou téléchargez la dernière version depuis la [page des Releases](https://github.com/donghao1393/mcp-dbutils/releases) et extrayez-la
 
-```dockerfile
-FROM python:3.10-slim
+2. Naviguez vers le répertoire du projet :
+   ```bash
+   cd mcp-dbutils
+   ```
 
-RUN pip install --no-cache-dir mcp-dbutils
+3. Construisez l'image Docker :
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
-COPY config.yaml /app/config.yaml
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--config", "/app/config.yaml"]
-```
-
-2. Construisez l'image en exécutant la commande suivante dans le répertoire contenant le Dockerfile :
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-> **Remarque** : Pour mettre à jour vers la dernière version, vous devrez reconstruire l'image pour obtenir la dernière version de MCP Database Utilities.
+> **Remarque** : Le répertoire racine du projet contient déjà un Dockerfile, vous n'avez donc pas besoin d'en créer un manuellement. Pour mettre à jour vers la dernière version, vous devrez obtenir le code le plus récent et reconstruire l'image.
 
 ### Étape 4 : Configurer votre application IA
 
@@ -326,11 +320,16 @@ uv pip install -U mcp-dbutils
 
 ### Option B (Docker) Mise à Jour
 
-Reconstruisez votre image Docker pour obtenir la dernière version :
+1. Obtenez le code du projet le plus récent :
+   ```bash
+   git pull
+   ```
+   Ou téléchargez la dernière version depuis la [page des Releases](https://github.com/donghao1393/mcp-dbutils/releases)
 
-```bash
-docker build -t mcp/dbutils .
-```
+2. Reconstruisez votre image Docker :
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
 ### Option C (Smithery) Mise à Jour
 

--- a/docs/fr/installation.md
+++ b/docs/fr/installation.md
@@ -130,7 +130,31 @@ Si vous n'avez pas Docker installé, téléchargez et installez-le depuis [docke
 
 Identique à l'Étape 2 de l'Option A, créez un fichier `config.yaml`.
 
-### Étape 3 : Configurer votre application IA
+### Étape 3 : Construire l'image Docker
+
+1. Créez un fichier nommé `Dockerfile` (sans extension) avec le contenu suivant :
+
+```dockerfile
+FROM python:3.10-slim
+
+RUN pip install --no-cache-dir mcp-dbutils
+
+WORKDIR /app
+COPY config.yaml /app/config.yaml
+
+ENTRYPOINT ["mcp-dbutils"]
+CMD ["--config", "/app/config.yaml"]
+```
+
+2. Construisez l'image en exécutant la commande suivante dans le répertoire contenant le Dockerfile :
+
+```bash
+docker build -t mcp/dbutils .
+```
+
+> **Remarque** : Pour mettre à jour vers la dernière version, vous devrez reconstruire l'image pour obtenir la dernière version de MCP Database Utilities.
+
+### Étape 4 : Configurer votre application IA
 
 #### Configuration de Claude Desktop
 
@@ -302,8 +326,10 @@ uv pip install -U mcp-dbutils
 
 ### Option B (Docker) Mise à Jour
 
+Reconstruisez votre image Docker pour obtenir la dernière version :
+
 ```bash
-docker pull mcp/dbutils:latest
+docker build -t mcp/dbutils .
 ```
 
 ### Option C (Smithery) Mise à Jour

--- a/docs/ru/installation-platform-specific.md
+++ b/docs/ru/installation-platform-specific.md
@@ -214,36 +214,30 @@ npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
 - Установленный и работающий Docker
 - Подключение к интернету (для загрузки Docker-образа)
 
-### Создание локального Docker-образа
+### Использование Docker-образа
 
-Из-за сетевых ограничений в некоторых регионах мы рекомендуем собирать Docker-образ локально:
+1. Получите код проекта:
+   ```bash
+   git clone https://github.com/donghao1393/mcp-dbutils.git
+   ```
+   Или загрузите последнюю версию со [страницы Releases](https://github.com/donghao1393/mcp-dbutils/releases) и распакуйте её
 
-1. Создайте Dockerfile:
+2. Перейдите в директорию проекта:
+   ```bash
+   cd mcp-dbutils
+   ```
 
-```dockerfile
-FROM python:3.10-slim
+3. Соберите образ MCP Database Utilities:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
+4. Настройте ваше ИИ-приложение для использования этого образа (см. [Руководство по установке](installation.md) Вариант B)
 
-RUN pip install --no-cache-dir mcp-dbutils
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--help"]
-```
-
-2. Соберите образ:
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-3. Запустите контейнер:
-
-```bash
-docker run -i --rm -v /путь/к/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
-```
-
-> **Примечание**: Для обновления до последней версии вам потребуется пересобрать образ, чтобы получить последнюю версию MCP Database Utilities.
+> **Примечание**:
+> - Корневая директория проекта уже содержит Dockerfile, поэтому вам не нужно создавать его вручную
+> - Для обновления до последней версии вам потребуется получить последний код и пересобрать образ
+> - Это сервис MCP, в основном предназначенный для вызова LLM в ИИ-приложениях, а не для запуска в качестве отдельного сервиса
 
 ## Офлайн-установка
 

--- a/docs/ru/installation-platform-specific.md
+++ b/docs/ru/installation-platform-specific.md
@@ -214,21 +214,11 @@ npx -y @smithery/cli install @donghao1393/mcp-dbutils --client claude
 - Установленный и работающий Docker
 - Подключение к интернету (для загрузки Docker-образа)
 
-### Использование официального Docker-образа
+### Создание локального Docker-образа
 
-1. Загрузите Docker-образ:
-   ```bash
-   docker pull mcp/dbutils
-   ```
+Из-за сетевых ограничений в некоторых регионах мы рекомендуем собирать Docker-образ локально:
 
-2. Запустите контейнер с вашим файлом конфигурации:
-   ```bash
-   docker run -i --rm -v /путь/к/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
-   ```
-
-### Создание пользовательского Docker-образа
-
-Если вам нужно настроить Docker-образ, вы можете создать свой собственный Dockerfile:
+1. Создайте Dockerfile:
 
 ```dockerfile
 FROM python:3.10-slim
@@ -241,12 +231,19 @@ ENTRYPOINT ["mcp-dbutils"]
 CMD ["--help"]
 ```
 
-Соберите и запустите ваш пользовательский образ:
+2. Соберите образ:
 
 ```bash
-docker build -t custom-mcp-dbutils .
-docker run -i --rm -v /путь/к/config.yaml:/app/config.yaml custom-mcp-dbutils --config /app/config.yaml
+docker build -t mcp/dbutils .
 ```
+
+3. Запустите контейнер:
+
+```bash
+docker run -i --rm -v /путь/к/config.yaml:/app/config.yaml mcp/dbutils --config /app/config.yaml
+```
+
+> **Примечание**: Для обновления до последней версии вам потребуется пересобрать образ, чтобы получить последнюю версию MCP Database Utilities.
 
 ## Офлайн-установка
 

--- a/docs/ru/installation.md
+++ b/docs/ru/installation.md
@@ -130,29 +130,23 @@ connections:
 
 Так же, как Шаг 2 в Варианте A, создайте файл `config.yaml`.
 
-### Шаг 3: Создайте Docker-образ
+### Шаг 3: Получите код проекта и создайте Docker-образ
 
-1. Создайте файл с именем `Dockerfile` (без расширения) со следующим содержимым:
+1. Сначала получите код проекта (выберите один из следующих методов):
+   - Клонируйте проект с GitHub: `git clone https://github.com/donghao1393/mcp-dbutils.git`
+   - Или загрузите последнюю версию со [страницы Releases](https://github.com/donghao1393/mcp-dbutils/releases) и распакуйте её
 
-```dockerfile
-FROM python:3.10-slim
+2. Перейдите в директорию проекта:
+   ```bash
+   cd mcp-dbutils
+   ```
 
-RUN pip install --no-cache-dir mcp-dbutils
+3. Соберите Docker-образ:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
-COPY config.yaml /app/config.yaml
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--config", "/app/config.yaml"]
-```
-
-2. Соберите образ, выполнив следующую команду в директории, содержащей Dockerfile:
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-> **Примечание**: Для обновления до последней версии вам потребуется пересобрать образ, чтобы получить последнюю версию MCP Database Utilities.
+> **Примечание**: Корневая директория проекта уже содержит Dockerfile, поэтому вам не нужно создавать его вручную. Для обновления до последней версии вам потребуется получить последний код и пересобрать образ.
 
 ### Шаг 4: Настройте ваше ИИ-приложение
 
@@ -326,11 +320,16 @@ uv pip install -U mcp-dbutils
 
 ### Обновление Варианта B (Docker)
 
-Пересоберите ваш Docker-образ для получения последней версии:
+1. Получите последний код проекта:
+   ```bash
+   git pull
+   ```
+   Или загрузите последнюю версию со [страницы Releases](https://github.com/donghao1393/mcp-dbutils/releases)
 
-```bash
-docker build -t mcp/dbutils .
-```
+2. Пересоберите ваш Docker-образ:
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
 ### Обновление Варианта C (Smithery)
 

--- a/docs/ru/installation.md
+++ b/docs/ru/installation.md
@@ -130,7 +130,31 @@ connections:
 
 Так же, как Шаг 2 в Варианте A, создайте файл `config.yaml`.
 
-### Шаг 3: Настройте ваше ИИ-приложение
+### Шаг 3: Создайте Docker-образ
+
+1. Создайте файл с именем `Dockerfile` (без расширения) со следующим содержимым:
+
+```dockerfile
+FROM python:3.10-slim
+
+RUN pip install --no-cache-dir mcp-dbutils
+
+WORKDIR /app
+COPY config.yaml /app/config.yaml
+
+ENTRYPOINT ["mcp-dbutils"]
+CMD ["--config", "/app/config.yaml"]
+```
+
+2. Соберите образ, выполнив следующую команду в директории, содержащей Dockerfile:
+
+```bash
+docker build -t mcp/dbutils .
+```
+
+> **Примечание**: Для обновления до последней версии вам потребуется пересобрать образ, чтобы получить последнюю версию MCP Database Utilities.
+
+### Шаг 4: Настройте ваше ИИ-приложение
 
 #### Настройка Claude Desktop
 
@@ -302,8 +326,10 @@ uv pip install -U mcp-dbutils
 
 ### Обновление Варианта B (Docker)
 
+Пересоберите ваш Docker-образ для получения последней версии:
+
 ```bash
-docker pull mcp/dbutils:latest
+docker build -t mcp/dbutils .
 ```
 
 ### Обновление Варианта C (Smithery)

--- a/docs/zh/installation-platform-specific.md
+++ b/docs/zh/installation-platform-specific.md
@@ -196,39 +196,30 @@ wsl --install
 
 ## Docker 安装指南
 
-### 构建本地镜像
+### 使用 Docker 镜像
 
-由于网络限制，我们推荐直接在本地构建 Docker 镜像：
+1. 获取项目代码：
+   ```bash
+   git clone https://github.com/donghao1393/mcp-dbutils.git
+   ```
+   或从 [Releases 页面](https://github.com/donghao1393/mcp-dbutils/releases) 下载最新版本的压缩包并解压
 
-1. 创建 Dockerfile：
+2. 进入项目目录：
+   ```bash
+   cd mcp-dbutils
+   ```
 
-```dockerfile
-FROM python:3.10-slim
+3. 构建 MCP 数据库工具镜像：
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-RUN pip install --no-cache-dir mcp-dbutils
+4. 在 AI 应用中配置使用该镜像（参见[安装指南](installation.md)中的方式 B）
 
-WORKDIR /app
-COPY config.yaml /app/config.yaml
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--config", "/app/config.yaml"]
-```
-
-2. 构建镜像：
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-3. 运行容器：
-
-```bash
-docker run -i --rm \
-  -v /path/to/config.yaml:/app/config.yaml \
-  mcp/dbutils --config /app/config.yaml
-```
-
-> **注意**：每次需要更新到最新版本时，您需要重新构建镜像以获取最新的 MCP 数据库工具版本。
+> **注意**：
+> - 项目根目录中已包含 Dockerfile，无需手动创建
+> - 每次需要更新到最新版本时，您需要重新获取最新代码并重新构建镜像
+> - 这是一个 MCP 服务，主要用于在 AI 应用中被 LLM 调用，而不是直接作为独立服务运行
 
 ## 故障排除
 

--- a/docs/zh/installation-platform-specific.md
+++ b/docs/zh/installation-platform-specific.md
@@ -196,23 +196,9 @@ wsl --install
 
 ## Docker 安装指南
 
-### 使用预构建镜像
+### 构建本地镜像
 
-1. 拉取 MCP 数据库工具镜像：
-
-```bash
-docker pull mcp/dbutils
-```
-
-2. 运行容器：
-
-```bash
-docker run -i --rm \
-  -v /path/to/config.yaml:/app/config.yaml \
-  mcp/dbutils --config /app/config.yaml
-```
-
-### 构建自定义镜像
+由于网络限制，我们推荐直接在本地构建 Docker 镜像：
 
 1. 创建 Dockerfile：
 
@@ -231,14 +217,18 @@ CMD ["--config", "/app/config.yaml"]
 2. 构建镜像：
 
 ```bash
-docker build -t custom-mcp-dbutils .
+docker build -t mcp/dbutils .
 ```
 
 3. 运行容器：
 
 ```bash
-docker run -i --rm custom-mcp-dbutils
+docker run -i --rm \
+  -v /path/to/config.yaml:/app/config.yaml \
+  mcp/dbutils --config /app/config.yaml
 ```
+
+> **注意**：每次需要更新到最新版本时，您需要重新构建镜像以获取最新的 MCP 数据库工具版本。
 
 ## 故障排除
 

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -130,7 +130,31 @@ connections:
 
 与方式 A 的步骤 2 相同，创建一个 `config.yaml` 文件。
 
-### 步骤 3：配置您的 AI 应用
+### 步骤 3：构建 Docker 镜像
+
+1. 创建一个名为 `Dockerfile` 的文件（无扩展名），内容如下：
+
+```dockerfile
+FROM python:3.10-slim
+
+RUN pip install --no-cache-dir mcp-dbutils
+
+WORKDIR /app
+COPY config.yaml /app/config.yaml
+
+ENTRYPOINT ["mcp-dbutils"]
+CMD ["--config", "/app/config.yaml"]
+```
+
+2. 在 Dockerfile 所在目录中运行以下命令构建镜像：
+
+```bash
+docker build -t mcp/dbutils .
+```
+
+> **注意**：每次需要更新到最新版本时，您需要重新构建镜像以获取最新的 MCP 数据库工具版本。
+
+### 步骤 4：配置您的 AI 应用
 
 #### Claude Desktop 配置
 
@@ -302,8 +326,10 @@ uv pip install -U mcp-dbutils
 
 ### 方式 B（Docker）更新
 
+重新构建您的 Docker 镜像以获取最新版本：
+
 ```bash
-docker pull mcp/dbutils:latest
+docker build -t mcp/dbutils .
 ```
 
 ### 方式 C（Smithery）更新

--- a/docs/zh/installation.md
+++ b/docs/zh/installation.md
@@ -130,29 +130,23 @@ connections:
 
 与方式 A 的步骤 2 相同，创建一个 `config.yaml` 文件。
 
-### 步骤 3：构建 Docker 镜像
+### 步骤 3：获取项目代码并构建 Docker 镜像
 
-1. 创建一个名为 `Dockerfile` 的文件（无扩展名），内容如下：
+1. 首先，获取项目代码（选择以下任一方式）：
+   - 从 GitHub 克隆项目：`git clone https://github.com/donghao1393/mcp-dbutils.git`
+   - 或从 [Releases 页面](https://github.com/donghao1393/mcp-dbutils/releases) 下载最新版本的压缩包并解压
 
-```dockerfile
-FROM python:3.10-slim
+2. 进入项目目录：
+   ```bash
+   cd mcp-dbutils
+   ```
 
-RUN pip install --no-cache-dir mcp-dbutils
+3. 构建 Docker 镜像：
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
-WORKDIR /app
-COPY config.yaml /app/config.yaml
-
-ENTRYPOINT ["mcp-dbutils"]
-CMD ["--config", "/app/config.yaml"]
-```
-
-2. 在 Dockerfile 所在目录中运行以下命令构建镜像：
-
-```bash
-docker build -t mcp/dbutils .
-```
-
-> **注意**：每次需要更新到最新版本时，您需要重新构建镜像以获取最新的 MCP 数据库工具版本。
+> **注意**：项目根目录中已包含 Dockerfile，无需手动创建。每次需要更新到最新版本时，您需要重新获取最新代码并重新构建镜像。
 
 ### 步骤 4：配置您的 AI 应用
 
@@ -326,11 +320,16 @@ uv pip install -U mcp-dbutils
 
 ### 方式 B（Docker）更新
 
-重新构建您的 Docker 镜像以获取最新版本：
+1. 获取最新的项目代码：
+   ```bash
+   git pull
+   ```
+   或从 [Releases 页面](https://github.com/donghao1393/mcp-dbutils/releases) 下载最新版本
 
-```bash
-docker build -t mcp/dbutils .
-```
+2. 重新构建 Docker 镜像：
+   ```bash
+   docker build -t mcp/dbutils .
+   ```
 
 ### 方式 C（Smithery）更新
 


### PR DESCRIPTION
## 问题描述

解决 #110 问题，修改所有语言版本的文档，添加获取项目代码的步骤，明确说明项目已包含Dockerfile，无需手动创建。

## 修改内容

1. 添加了获取项目代码的详细步骤（通过git clone或下载release包）
2. 添加了进入项目目录的步骤
3. 更新了版本更新部分，添加了获取最新代码的步骤
4. 明确说明项目已包含Dockerfile，无需手动创建
5. 说明MCP服务的性质，主要用于在AI应用中被LLM调用，而不是直接作为独立服务运行

## 测试

已手动检查所有语言版本的文档，确保修改一致且格式正确。